### PR TITLE
fixed so names with Å are cropped: #11246

### DIFF
--- a/source/css/scss/objects/_header.scss
+++ b/source/css/scss/objects/_header.scss
@@ -324,6 +324,7 @@
 
     span {
       overflow: hidden !important;
+      line-height: 1.6;
       text-overflow: ellipsis;
     }
   }


### PR DESCRIPTION
Tall characters like Å are cropped. we set the line-height to 1.6 to get around this. Is there a better way to fix this?