### PR TITLE
News Archive - implemented the load more functionality.

### DIFF
--- a/source/_patterns/03-maler-infoportal/20-navigasjonssider/60-arkiv.mustache
+++ b/source/_patterns/03-maler-infoportal/20-navigasjonssider/60-arkiv.mustache
@@ -27,7 +27,7 @@
 			</div>
 
 			<div class="row">
-				<div class="col-sm-12 col-lg-10 offset-lg-1 pb-3">
+				<div class="col-sm-12 col-lg-10 offset-lg-1 pb-3 {{articlesContainerClass}}">
 
 					{{# list-article }}
 							{{> molekyler-lenketittel-med-forklaring }}

--- a/source/_patterns/04-sider-infoportal/20-navigasjonssider/60-arkiv-v-nyhetsarkiv.json
+++ b/source/_patterns/04-sider-infoportal/20-navigasjonssider/60-arkiv-v-nyhetsarkiv.json
@@ -8,7 +8,9 @@
 
 		"login-or-switchuser": "",
 	  "data-toggle-personInfo": "dropdown",
-		"url": "#",
+    "url": "#",
+    
+    "articlesContainerClass": "newsArchive",
 
 		"article-breadcrumb": {
 			"breadcrumb-item": [
@@ -93,7 +95,7 @@
 		],
 		"list-article-loadmore": {
 	    "action-button-text": "Last flere",
-	    "button-class": "a-btn a-btn-action a-fullWidthBtn",
+	    "button-class": "a-btn a-btn-action a-fullWidthBtn a-btn-loadMore",
 	    "icon-prefix": "ai",
 	    "icon-class": "ai-plus",
 	    "icon-extra-class": ""

--- a/source/_patterns/04-sider-infoportal/20-navigasjonssider/60-arkiv-v-nyhetsarkiv.json
+++ b/source/_patterns/04-sider-infoportal/20-navigasjonssider/60-arkiv-v-nyhetsarkiv.json
@@ -10,7 +10,7 @@
 	  "data-toggle-personInfo": "dropdown",
     "url": "#",
     
-    "articlesContainerClass": "newsArchive",
+    "articlesContainerClass": "a-newsArchive",
 
 		"article-breadcrumb": {
 			"breadcrumb-item": [

--- a/source/css/scss/objects/_newsArchive.scss
+++ b/source/css/scss/objects/_newsArchive.scss
@@ -1,5 +1,9 @@
-.newsArchive {
-  article:nth-child(n+6).a-linkArticle {
-    display: none;
+.a-newsArchive {
+  article {
+    &:nth-child(n+6) {
+      &.a-linkArticle {
+        display: none;
+      }
+    }
   }
 }

--- a/source/css/scss/objects/_newsArchive.scss
+++ b/source/css/scss/objects/_newsArchive.scss
@@ -1,0 +1,5 @@
+.newsArchive {
+  article:nth-child(n+6).a-linkArticle {
+    display: none;
+  }
+}

--- a/source/css/style.scss
+++ b/source/css/style.scss
@@ -98,6 +98,7 @@ Atomic Designsystem built with Pattern Lab (http://patternlab.io/)
 
 @import "scss/objects/header";
 @import "scss/objects/colnav";
+@import "scss/objects/newsArchive";
 @import "scss/objects/nav";
 @import "scss/objects/footer";
 @import "scss/objects/icons";

--- a/source/js/production/infoportal/00-modules/newArchive.js
+++ b/source/js/production/infoportal/00-modules/newArchive.js
@@ -1,0 +1,32 @@
+/* globals $ */
+
+var newsArchive = function() {
+  var page = 1;
+  var numberOfItemsPerPage = 5;
+  var rootSelector = '.newsArchive';
+  var articleCssSelector = '.a-linkArticle';
+  var $loadMoreButton = $('.a-btn-loadMore');
+  var articlesCount = $(articleCssSelector).length;
+
+  function visibleItems() {
+    return page * numberOfItemsPerPage;
+  }
+
+  function setButtonVisibility() {
+    if (articlesCount <= visibleItems()) {
+      $loadMoreButton.hide();
+    }
+  }
+
+  if ($(rootSelector).length > 0) {
+    $loadMoreButton.on('click', function() {
+      var articles;
+      page += 1;
+      $(':nth-child(n+' + (visibleItems() + 1) + ')' + articleCssSelector).hide();
+      $(':nth-child(-n+' + visibleItems() + ')' + articleCssSelector).show();
+      setButtonVisibility();
+    });
+
+    setButtonVisibility();
+  }
+};

--- a/source/js/production/infoportal/00-modules/newsArchive.js
+++ b/source/js/production/infoportal/00-modules/newsArchive.js
@@ -3,7 +3,7 @@
 var newsArchive = function() {
   var page = 1;
   var numberOfItemsPerPage = 5;
-  var rootSelector = '.newsArchive';
+  var rootSelector = '.a-newsArchive';
   var articleCssSelector = '.a-linkArticle';
   var $loadMoreButton = $('.a-btn-loadMore');
   var articlesCount = $(articleCssSelector).length;

--- a/source/js/production/infoportal/init.js
+++ b/source/js/production/infoportal/init.js
@@ -6,7 +6,8 @@
   articleAnchors,
   subscribe,
   setupFormValidation,
-  listenForAttachmentChanges
+  listenForAttachmentChanges,
+  newsArchive
 */
 window.infoportalInit = function() {
   colnavCustom();
@@ -17,6 +18,7 @@ window.infoportalInit = function() {
   subscribe();
   setupFormValidation();
   listenForAttachmentChanges();
+  newsArchive();
   function setupForm1() {
     $('body').off('focus', '#contactForm', setupForm1);
     setupFormValidation('#contactForm', '#a-js-contactForm-submit');


### PR DESCRIPTION
Implemented the "load more" functionality for the news archive. For now we go the simple route, we load all the articles (should be rendered in the page by the server) and hide from the 6th on. Then the button shows them in batches of 5. It would be good to load them from the server in the future, but there's no API route at the moment, so I think this is OK to start with.