### PR TITLE
Gulp export task for Jekyll

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -503,6 +503,13 @@ gulp.task('default', gulp.series('patternlab:serve-all'));
 /** ***************************************************
  * COPY TASKS - stream assets from source to destination
 ******************************************************/
+gulp.task('clean:styleguide-dest-paths', function (done) {
+  del([
+    '../designsystem-styleguide/_includes/patterns/**/*',
+    '../designsystem-styleguide/patterns/**/*'
+  ], { force: true });
+  done();
+});
 
 // This is the task that exports the results from Pattern Lab
 // into the Jekyll style guide that lives outside of this repository
@@ -515,6 +522,9 @@ gulp.task('copy:export-to-styleguide', function(done) {
     .pipe(regexRename(/atomer/g, 'atoms'))
     .pipe(regexRename(/molekyler/g, 'molecules'))
     .pipe(regexRename(/organismer/g, 'organisms'))
+    .pipe(replace(new RegExp('<!-- START.*-->', 'g'), ''))
+    .pipe(replace(new RegExp('<!-- END.*-->', 'g'), ''))
+    .pipe(replace(new RegExp('[\n\r]{2,}', 'g'), '\n\r'))
     .pipe(replace('<body class=""', '<body class="a-bgWhite p-1"'))
     .pipe(gulp.dest('../designsystem-styleguide/_includes/patterns'));
 
@@ -558,4 +568,4 @@ gulp.task('copy:export-to-styleguide', function(done) {
 /** ***************************************************
  * COMPOUND TASKS
 ******************************************************/
-gulp.task('style-guide-export', gulp.series('copy:export-to-styleguide'));
+gulp.task('style-guide-export', gulp.series('clean:styleguide-dest-paths', 'copy:export-to-styleguide'));


### PR DESCRIPTION
The style-guide-export task now cleans the output directory first, and removes the html comments from the snippets.