### PR TITLE
Workaround for iOS 11 cursor bug

### DIFF
--- a/config/gulp/config.json
+++ b/config/gulp/config.json
@@ -65,6 +65,7 @@
             "source/js/production/modules/popover.js",
             "source/js/production/modules/expandContent.js",
             "source/js/production/modules/searchFilterView.js",
+            "source/js/production/modules/ios11BugWorkaround.js",
             "source/js/production/portal-init.js"
           ]
         }
@@ -127,6 +128,7 @@
             "source/js/production/modules/popover.js",
             "source/js/production/modules/expandContent.js",
             "source/js/production/modules/searchFilterView.js",
+            "source/js/production/modules/ios11BugWorkaround.js",
             "source/js/production/infoportal-init.js"
           ]
         }
@@ -173,6 +175,7 @@
             "source/js/production/modules/validation.js",
             "source/js/production/modules/popover.js",
             "source/js/production/modules/expandContent.js",
+            "source/js/production/modules/ios11BugWorkaround.js",
             "source/js/production/infoportal-frontpage-init.js"
           ]
         }

--- a/source/js/production/modules/ios11BugWorkaround.js
+++ b/source/js/production/modules/ios11BugWorkaround.js
@@ -1,0 +1,16 @@
+$(document).ready(function() {
+  // Detect iOS 11_x affected by cursor position bug
+  // Bug report: https://bugs.webkit.org/show_bug.cgi?id=176896
+  // Needs to be updated if new versions are affected
+  var ua = navigator.userAgent;
+  var iOS = /iPad|iPhone|iPod/.test(ua);
+  var iOS11 = /OS 11_/.test(ua);
+
+  // Only apply this in the parent page, not in the modal
+  if ($('body.a-stickyHelp-body').length === 0 && iOS && iOS11) {
+    document.body.style.overflow = 'hidden';
+    document.body.style.height = '100%';
+    document.body.style.width = '100%';
+    document.body.style.position = 'fixed';
+  }
+});


### PR DESCRIPTION
Workaround for a bug in iOS 11 that shows the cursor outside the input field the focus is on. Ref: https://bugs.webkit.org/show_bug.cgi?id=176896
You can see a GIF of it here: https://cdn-images-1.medium.com/max/1600/1*7ipWw7SAQ1VVJxnCUM933w.gif