### PR TITLE
Mrosvik/search results line fix

### DIFF
--- a/source/css/scss/objects/_searchresults.scss
+++ b/source/css/scss/objects/_searchresults.scss
@@ -88,4 +88,10 @@
       margin-top: -$spacer / 2;
     }
   }
+
+  .a-iconText {
+    &.a-iconText-background--white {
+      margin-top: -1px; // This will ensure that if a search result above has a bottom-border, the border will hide behind this box, and not be double.
+    }
+  }
 }


### PR DESCRIPTION
Minus 1px in top, this will ensure that if a search result above has a bottom-border, the border will hide behind this box, and not be double