### PR TITLE
Added border radius 0 to buttons

### DIFF
--- a/source/css/scss/objects/_buttons.scss
+++ b/source/css/scss/objects/_buttons.scss
@@ -13,6 +13,7 @@
   cursor: pointer;
   background: $blue;
   border: none;
+  border-radius: 0;
 
   &:hover {
     color: $black;


### PR DESCRIPTION
Chrome 62 adds a default border radius to <button> on macOS
Added border radius none to overwrite this.
https://www.chromestatus.com/features/5743649186906112