### PR TITLE
Changes to actor selection in search across

### DIFF
--- a/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg.json
+++ b/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg.json
@@ -442,8 +442,18 @@
           "topRadioButtons": [
             {
               "radiobuttons": {
-                "radiobuttons-title": "Alle jeg kan representere",
+                "radiobuttons-title": "Alle personer og hovedenheter",
                 "radiobuttons-id": "alle-jeg-kan-representere-checkbutton-1",
+                "radiobuttons-class": "d-block mb-1",
+                "radiobuttons-name": "selectProfile",
+                "isChecked": true,
+                "hasIcon": false
+              }
+            },
+            {
+              "radiobuttons": {
+                "radiobuttons-title": "Alle, inkludert underenheter",
+                "radiobuttons-id": "alle-jeg-kan-representere-checkbutton-3",
                 "radiobuttons-class": "d-block mb-1",
                 "radiobuttons-name": "selectProfile",
                 "isChecked": true,
@@ -496,7 +506,7 @@
           },
           "select-subunits": {
             "check-legend": false,
-            "styleModifier": "float-lg-right small-checkboxes",
+            "styleModifier": "float-lg-right a-form-checkboxes--discret",
             "checkboxes": [
               {
                 "checkboxes-title": "Se alle underenheter"
@@ -505,7 +515,7 @@
           },
           "select-inactive": {
             "check-legend": false,
-            "styleModifier": "float-lg-right small-checkboxes",
+            "styleModifier": "float-lg-right a-form-checkboxes--discret",
             "checkboxes": [
               {
                 "checkboxes-title": "Se slettede enheter"
@@ -558,7 +568,7 @@
                     }
                   ],
                   "secondLevelCheckboxes": {
-                    "styleModifier": "a-search-multiple-actor-select small-checkboxes",
+                    "styleModifier": "a-search-multiple-actor-select a-search-multiple-actor-select-subunit a-form-checkboxes--discret",
                     "checkboxes": [
                       {
                         "checkboxes-title": "<b>Velg alle</b>"
@@ -585,7 +595,7 @@
                     }
                   ],
                   "secondLevelCheckboxes": {
-                    "styleModifier": "a-search-multiple-actor-select small-checkboxes",
+                    "styleModifier": "a-search-multiple-actor-select a-search-multiple-actor-select-subunit a-form-checkboxes--discret",
                     "checkboxes": [
                       {
                         "checkboxes-title": "<b>Velg alle</b>",
@@ -624,7 +634,7 @@
                     }
                   ],
                   "secondLevelCheckboxes": {
-                    "styleModifier": "a-search-multiple-actor-select small-checkboxes",
+                    "styleModifier": "a-search-multiple-actor-select a-search-multiple-actor-select-subunit a-form-checkboxes--discret",
                     "checkboxes": [
                       {
                         "checkboxes-title": "<b>Eneste Underorganisasjon AS</b> org. nr. 123 456 002"

--- a/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg~forste-gang.json
+++ b/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg~forste-gang.json
@@ -445,8 +445,18 @@
             "topRadioButtons": [
               {
                 "radiobuttons": {
-                  "radiobuttons-title": "Alle jeg kan representere",
+                  "radiobuttons-title": "Alle personer og hovedenheter",
                   "radiobuttons-id": "alle-jeg-kan-representere-checkbutton-1",
+                  "radiobuttons-class": "d-block mb-1",
+                  "radiobuttons-name": "selectProfile",
+                  "isChecked": true,
+                  "hasIcon": false
+                }
+              },
+              {
+                "radiobuttons": {
+                  "radiobuttons-title": "Alle, inkludert underenheter",
+                  "radiobuttons-id": "alle-jeg-kan-representere-checkbutton-3",
                   "radiobuttons-class": "d-block mb-1",
                   "radiobuttons-name": "selectProfile",
                   "isChecked": true,
@@ -499,7 +509,7 @@
             },
             "select-subunits": {
               "check-legend": false,
-              "styleModifier": "float-lg-right small-checkboxes",
+              "styleModifier": "float-lg-right a-form-checkboxes--discret",
               "checkboxes": [
                 {
                   "checkboxes-title": "Se alle underenheter"
@@ -508,7 +518,7 @@
             },
             "select-inactive": {
               "check-legend": false,
-              "styleModifier": "float-lg-right small-checkboxes",
+              "styleModifier": "float-lg-right a-form-checkboxes--discret",
               "checkboxes": [
                 {
                   "checkboxes-title": "Se slettede enheter"
@@ -561,7 +571,7 @@
                       }
                     ],
                     "secondLevelCheckboxes": {
-                      "styleModifier": "a-search-multiple-actor-select small-checkboxes",
+                      "styleModifier": "a-search-multiple-actor-select a-form-checkboxes--discret",
                       "checkboxes": [
                         {
                           "checkboxes-title": "<b>Velg alle</b>"
@@ -588,7 +598,7 @@
                       }
                     ],
                     "secondLevelCheckboxes": {
-                      "styleModifier": "a-search-multiple-actor-select small-checkboxes",
+                      "styleModifier": "a-search-multiple-actor-select a-form-checkboxes--discret",
                       "checkboxes": [
                         {
                           "checkboxes-title": "<b>Velg alle</b>",
@@ -627,7 +637,7 @@
                       }
                     ],
                     "secondLevelCheckboxes": {
-                      "styleModifier": "a-search-multiple-actor-select small-checkboxes",
+                      "styleModifier": "a-search-multiple-actor-select a-form-checkboxes--discret",
                       "checkboxes": [
                         {
                           "checkboxes-title": "<b>Eneste Underorganisasjon AS</b> org. nr. 123 456 002"

--- a/source/_patterns/04-sider-portal/01-aktorvalg/15-aktorvalg-rediger-lagrede-sok.json
+++ b/source/_patterns/04-sider-portal/01-aktorvalg/15-aktorvalg-rediger-lagrede-sok.json
@@ -35,7 +35,7 @@
       "link-text": "Rediger lagrede søk",
       "link-url": "javascript:;",
       "link-class": "no-decoration text-right a-fontBold a-js-toggleEdit"
-    },    
+    },
     "custom-title": {
       "text-items": [
         {
@@ -67,7 +67,7 @@
                 },
                 {
                   "column-text": {
-                    "text": "(&#171;NAV&#187; + siste 12 måneder + Alle jeg kan representere)"
+                    "text": "(&#171;NAV&#187; + siste 12 måneder + Alle personer og hovedenheter)"
                   }
                 }
               ]

--- a/source/_patterns/04-sider-portal/50-innboks/20-innboks-soketreff-tvers.json
+++ b/source/_patterns/04-sider-portal/50-innboks/20-innboks-soketreff-tvers.json
@@ -964,8 +964,18 @@
               "topRadioButtons": [
                 {
                   "radiobuttons": {
-                    "radiobuttons-title": "Alle jeg kan representere",
+                    "radiobuttons-title": "Alle personer og hovedenheter",
                     "radiobuttons-id": "alle-jeg-kan-representere-checkbutton-1",
+                    "radiobuttons-class": "d-block mb-1",
+                    "radiobuttons-name": "selectProfile",
+                    "isChecked": true,
+                    "hasIcon": false
+                  }
+                },
+                {
+                  "radiobuttons": {
+                    "radiobuttons-title": "Alle, inkludert underenheter",
+                    "radiobuttons-id": "alle-jeg-kan-representere-checkbutton-3",
                     "radiobuttons-class": "d-block mb-1",
                     "radiobuttons-name": "selectProfile",
                     "isChecked": true,
@@ -1001,7 +1011,7 @@
                 "form-label-hasIcon": {
                   "icon-prefix": "ai",
                   "icon-class": "ai-others"
-                }    
+                }
               },
               "select-all": {
                   "check-legend": false,
@@ -1086,7 +1096,7 @@
                 {
                   "checkbox-list-id": "selectedProfiles",
                   "firstLevelCheckboxes": [
-                    
+
                   ]
                 }
               ]

--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -571,20 +571,6 @@ textarea {
     }
   }
 
-  &.small-checkboxes {
-    .custom-control-indicator {
-      width: 18px;
-      height: 18px;
-      margin-top: -1px;
-      border-color: $black;
-      border-width: 1px;
-    }
-
-    .custom-control {
-      @include a-fontSize14;
-    }
-  }
-
   &.a-search-multiple-actor-select {
     .inactive {
       cursor: not-allowed;
@@ -593,6 +579,10 @@ textarea {
         color: $grey-medium;
       }
     }
+  }
+
+  &.a-search-multiple-actor-select-subunit {
+    margin-left: 30px;
   }
 
   &.a-form-checkboxes--discret {

--- a/source/js/prototyping/modules/toggleSelectProfiles.js
+++ b/source/js/prototyping/modules/toggleSelectProfiles.js
@@ -3,7 +3,7 @@ var toggleSelectProfiles = function() {
   $('#selectedProfiles').hide();
   $('#profile-selection').hide();
 
-  $('#alle-jeg-kan-representere-checkbutton-1').on('click', function() {
+  $('#alle-jeg-kan-representere-checkbutton-1,#alle-jeg-kan-representere-checkbutton-3').on('click', function() {
     $('#profile-selection').hide();
   });
   $('#select-profile-checkbutton-2').on('click', function() {


### PR DESCRIPTION
- Substitute "small-checkboxes" with discreet variant (fixed in portal)
- Update button texts for actor selection
- Add "with subunits" option for actor selection
- Increase indentation of subunits displayed in actor selection

Denne PRen implementerer endringer som er blitt hotfikset inn i portal, samt en forbedring til utlisting av underaktører som er blitt bestilt av UX.

Siden det gjøres endringer i common CSS, legger jeg for ordens skyld inn flere reviewers, selv om klassene som her er brukt kun er benyttet i portal. "small-checkboxes" fjernes, da denne type checkbox finnes fra før i a-form-checkboxes--discret (portal er allerede oppdater med dette, så det er trygt å fjerne klassent).