### PR TITLE
Changed card from flex to block for printing

### DIFF
--- a/source/css/scss-altinn/objects/_print.scss
+++ b/source/css/scss-altinn/objects/_print.scss
@@ -63,4 +63,9 @@
   .a-js-result {
     display: block !important;
   }
+
+  // Fix for IE and Firefox cutting of flexbox when printing on multiple pages
+  .card {
+    display: block !important; 
+  }
 }


### PR DESCRIPTION
Fix for IE and Firefox cutting of flexboesx when printing on multiple pages.

#13533 Lange utskrifter kuttes, kun første side kommer med