### PR TITLE
mrosvik/css-lintfix-altinnett

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -13,11 +13,11 @@ merge-default-rules: false
 
 # File Options
 files:
-  include: 
+  include:
     #- 'source/css/**/*.s+(a|c)ss'
     - 'source/css/scss-altinn/**/*.s+(a|c)ss'
     - 'source/css/scss-common/**/*.s+(a|c)ss'
-    #- 'source/css/scss-altinnett/**/*.s+(a|c)ss'
+    - 'source/css/scss-altinnett/**/*.s+(a|c)ss'
     #- 'source/css/scss-brreg/**/*.s+(a|c)ss'
   ignore:
     - 'sass/vendor/**/*.*'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,10 +124,6 @@ gulp.task('pl-copy:distribution-css', function(done) {
         console.log(err);
       }
 
-      src = custom.replace('@import "scss/episerver/profile-presentation";',
-        '// Automatically removed');
-      src = src.replace('@import "scss/episerver/episerver";',
-        '// Automatically removed');
       fs.writeFileSync('./source/css/' + element.scssFilename + '-temp.scss', src);
       gulp.src(paths().source.css + element.scssFilename + '-temp.scss')
         .pipe(sass().on('error', sass.logError))

--- a/source/css/scss-altinnett/objects/_lists.scss
+++ b/source/css/scss-altinnett/objects/_lists.scss
@@ -1,13 +1,1 @@
-.project-altinnett {
-  .a-list {
-    li {
-      &.a-clickable {
-        &.a-list-hasRowLink {
-          &:hover {
-            background-color: yellow;
-          }
-        }
-      }
-    }
-  }
-}
+

--- a/source/css/style.dist.infoportal.scss
+++ b/source/css/style.dist.infoportal.scss
@@ -69,4 +69,4 @@ $images-base-url: '../images/';
 
 
 /*-- EPISERVER SPECIFIC --*/
-@import 'scss/episerver/episerver';
+@import 'scss-altinn/episerver/episerver';


### PR DESCRIPTION
- Removed unused lines from gulp file
- Updated episerver css with correct path
- Removed css lint errors from altinett (was only dummy css added for testing in an early stage)