### PR TITLE
mrosvik/added altinn as state

### DIFF
--- a/source/_patterns/00-atomer/01-forms/00-avkrysningsboks.md
+++ b/source/_patterns/00-atomer/01-forms/00-avkrysningsboks.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Avkrysningsbokser brukes i tilfeller der brukeren får et spørsmål og kan svare med et eller flere alternativer.

--- a/source/_patterns/00-atomer/01-forms/01-♺-avkrysningsboks-stacked.md
+++ b/source/_patterns/00-atomer/01-forms/01-♺-avkrysningsboks-stacked.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 prepend: <!-- Dummy prepended content -->
 append: <!-- Dummy appended content -->
 version: 1

--- a/source/_patterns/00-atomer/01-forms/02-♺-avkrysningsboks-diskret.md
+++ b/source/_patterns/00-atomer/01-forms/02-♺-avkrysningsboks-diskret.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 Avkrysningsbokser brukes i tilfeller der brukeren får et spørsmål og kan svare med et eller flere alternativer.

--- a/source/_patterns/00-atomer/01-forms/03-valgknapp.md
+++ b/source/_patterns/00-atomer/01-forms/03-valgknapp.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Brukes i tilfeller der brukeren kan gjøre flere valg for å aktivere noe. F.eks aktivere filter, rettigheter, eller annet.  Denne støtter nå forskjellig ikon for checked og not checked states. Den støtter også popover.

--- a/source/_patterns/00-atomer/01-forms/04-radioknapp.md
+++ b/source/_patterns/00-atomer/01-forms/04-radioknapp.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Brukes i tilfeller der brukeren kun kan velge en verdi blant flere tilgjengelige. Radio-buttons brukes per nå bare fra attraktivitetsprosjektet, og skal brukes når det er valg med større mengder informasjon.

--- a/source/_patterns/00-atomer/01-forms/05-♺-radioknapp-stacked.md
+++ b/source/_patterns/00-atomer/01-forms/05-♺-radioknapp-stacked.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Brukes i tilfeller der brukeren kun kan velge en verdi blant flere tilgjengelige.

--- a/source/_patterns/00-atomer/01-forms/06-♺-radioknapp-med-utdrag.md
+++ b/source/_patterns/00-atomer/01-forms/06-♺-radioknapp-med-utdrag.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 Fra Attraktivitetsprosjektet, og ikke i bruk. Må revurderes om den skal brukes.

--- a/source/_patterns/00-atomer/01-forms/07-valgknapp-ett-alternativ.md
+++ b/source/_patterns/00-atomer/01-forms/07-valgknapp-ett-alternativ.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Brukes i tilfeller der brukeren kan gjøre flere valg for å aktivere noe. F.eks aktivere filter, rettigheter, eller annet.  

--- a/source/_patterns/00-atomer/01-forms/10-tekst-input.md
+++ b/source/_patterns/00-atomer/01-forms/10-tekst-input.md
@@ -1,7 +1,6 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 js: handleFocus.js
 ---
 Tekstfelt brukes når vanlig tekst skal fylles inn, f.eks navn. Label settes foran input-område.
-

--- a/source/_patterns/00-atomer/01-forms/11-♺-tekst-input-stor.md
+++ b/source/_patterns/00-atomer/01-forms/11-♺-tekst-input-stor.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: searchWithHighlight.js hvis data-search-algorithm="show-and-highlight"
 ---

--- a/source/_patterns/00-atomer/01-forms/12-♺-tekst-input-labelSkjult.md
+++ b/source/_patterns/00-atomer/01-forms/12-♺-tekst-input-labelSkjult.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Samme som tekst input, men label er skjult med sr-only (kun synlig for skjermlesere)

--- a/source/_patterns/00-atomer/01-forms/13-♺-tekst-input-label-inni.md
+++ b/source/_patterns/00-atomer/01-forms/13-♺-tekst-input-label-inni.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 0
 ---
 Tekstfelt brukes når vanlig tekst skal fylles inn, f.eks navn. Label settes foran input-område.

--- a/source/_patterns/00-atomer/01-forms/14-♺-tekst-input-hjelpetekst.md
+++ b/source/_patterns/00-atomer/01-forms/14-♺-tekst-input-hjelpetekst.md
@@ -1,6 +1,6 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Samme som tekst input, men label er skjult med sr-only (kun synlig for skjermlesere).
-Brukt i attraktivitetsprojektet, så arkiveres til den er nødvendig. 
+Brukt i attraktivitetsprojektet, så arkiveres til den er nødvendig.

--- a/source/_patterns/00-atomer/01-forms/16-♺-tekst-input-label-inni-med-validator.md
+++ b/source/_patterns/00-atomer/01-forms/16-♺-tekst-input-label-inni-med-validator.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 0
 ---
 Tekstfelt brukes når vanlig tekst skal fylles inn, f.eks navn. Label settes foran input-område.

--- a/source/_patterns/00-atomer/01-forms/17-♺-input-deaktivert.md
+++ b/source/_patterns/00-atomer/01-forms/17-♺-input-deaktivert.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/01-forms/20-♺-epost.md
+++ b/source/_patterns/00-atomer/01-forms/20-♺-epost.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Brukes når epost skal fylles ut av brukeren. Dersom informasjonen som blir lagt inn i feltet er mangelfull, f.eks mangler krøllalfa, vil feilmelding dukke opp etter noen sekunder. Feltet vil da bli rødt.

--- a/source/_patterns/00-atomer/01-forms/21-♺-tekst-input-postnummer.md
+++ b/source/_patterns/00-atomer/01-forms/21-♺-tekst-input-postnummer.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 0
 ---
 Tekstfelt brukes når vanlig tekst skal fylles inn, f.eks navn. Label settes foran input-område.

--- a/source/_patterns/00-atomer/01-forms/22-♺-telefonnummer-input.md
+++ b/source/_patterns/00-atomer/01-forms/22-♺-telefonnummer-input.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Brukes når telefonnummer skal fylles inn. Feimelding kommer umiddelbart dersom bruker forsøker å skrive noe annet en siffer.

--- a/source/_patterns/00-atomer/01-forms/23-♺-personnummer.md
+++ b/source/_patterns/00-atomer/01-forms/23-♺-personnummer.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Brukes når fødselsnummer skal fylles ut. Feimelding dukker opp dersom bruker forsøker å skrive noe annet en siffer.

--- a/source/_patterns/00-atomer/01-forms/24-♺-passord-input.md
+++ b/source/_patterns/00-atomer/01-forms/24-♺-passord-input.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: showPassword.js
 ---

--- a/source/_patterns/00-atomer/01-forms/25-♺-input-godkjent.md
+++ b/source/_patterns/00-atomer/01-forms/25-♺-input-godkjent.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/01-forms/30-♺-sok.md
+++ b/source/_patterns/00-atomer/01-forms/30-♺-sok.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 Vi bruker [HTML5 search input type](http://dev.w3.org/html5/markup/input.search.html), som gjør at mange mobile enheter kan [velge riktig tastatur for formålet.](http://diveintohtml5.info/forms.html)

--- a/source/_patterns/00-atomer/01-forms/31-♺-sok-stor.md
+++ b/source/_patterns/00-atomer/01-forms/31-♺-sok-stor.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 Stort søkefelt brukes på sidemaler der søk vises øverst og har hovedfokus.

--- a/source/_patterns/00-atomer/01-forms/32-♺-sok-stor-avansert.md
+++ b/source/_patterns/00-atomer/01-forms/32-♺-sok-stor-avansert.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 Stort søkefelt brukes på sidemaler der søk vises øverst med avansert knapp og har hovedfokus.

--- a/source/_patterns/00-atomer/01-forms/35-♺-sok-tema.md
+++ b/source/_patterns/00-atomer/01-forms/35-♺-sok-tema.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Søk innenfor et område. Ikon til venstre beskriver hva man søker i. F.eks tjenester, datalister, etc.

--- a/source/_patterns/00-atomer/01-forms/36-♺-sok-tema-autocomplete.md
+++ b/source/_patterns/00-atomer/01-forms/36-♺-sok-tema-autocomplete.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: searchWithAutocomplete.js
 ---

--- a/source/_patterns/00-atomer/01-forms/37-♺-sok-tema-inaktiv.md
+++ b/source/_patterns/00-atomer/01-forms/37-♺-sok-tema-inaktiv.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Inaktivt søkefelt. Ikon til venstre beskriver hva man søker i. F.eks tjenester, datalister, etc.

--- a/source/_patterns/00-atomer/01-forms/40-tekstfelt.md
+++ b/source/_patterns/00-atomer/01-forms/40-tekstfelt.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Tekstfelt

--- a/source/_patterns/00-atomer/01-forms/50-flervalg-stilisert.md
+++ b/source/_patterns/00-atomer/01-forms/50-flervalg-stilisert.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Brukes når brukeren skal velge et av flere alternativ. Denne varianten er stilsatt og vil se lik ut på alle enheter.

--- a/source/_patterns/00-atomer/01-forms/60-datovelger.md
+++ b/source/_patterns/00-atomer/01-forms/60-datovelger.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn altinnett
 version: 1
 js: initializeDatepicker.js. Requires class .form-control.date
 ---

--- a/source/_patterns/00-atomer/01-forms/70-upload.md
+++ b/source/_patterns/00-atomer/01-forms/70-upload.md
@@ -1,6 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Generic upload button with optional label
-

--- a/source/_patterns/00-atomer/01-forms/_71-fileupload-klientdelegering.md
+++ b/source/_patterns/00-atomer/01-forms/_71-fileupload-klientdelegering.md
@@ -1,7 +1,6 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: fileInputHandler.js
 ---
 Custom input type=file with javascript for displaying the selected file. Only supports selection of 1 file. Can be displayed with or without list
-

--- a/source/_patterns/00-atomer/02-lenker/00-link.md
+++ b/source/_patterns/00-atomer/02-lenker/00-link.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 En vanlig lenke som benytter < a >...< /a > er blå med 2px strek under.

--- a/source/_patterns/00-atomer/02-lenker/02-♺-link-ekstern.md
+++ b/source/_patterns/00-atomer/02-lenker/02-♺-link-ekstern.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Når man lenker til en ekstern side, altså en side utenfor altinn.no, skal det vises en pil opp ved siden av lenketeksten. Dette oppdages automatisk (dersom man refererer til "http://" utenfor altinn), så man trenger ikke legge på denne pilen manuelt.

--- a/source/_patterns/00-atomer/02-lenker/03-♺-link-fremhevet.md
+++ b/source/_patterns/00-atomer/02-lenker/03-♺-link-fremhevet.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Denne lenken kan brukes på utvalgte steder for å oppfordre brukeren til en oppgave eller henvise til en oversikt. For eksempel i slutten av lister, etc.

--- a/source/_patterns/00-atomer/02-lenker/05-♺-link-knapp.md
+++ b/source/_patterns/00-atomer/02-lenker/05-♺-link-knapp.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 NB: Dette er en variant av [link.mustache]

--- a/source/_patterns/00-atomer/02-lenker/09-♺-link-knapp-stor.md
+++ b/source/_patterns/00-atomer/02-lenker/09-♺-link-knapp-stor.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 NB: Dette er en variant av [link.mustache]

--- a/source/_patterns/00-atomer/02-lenker/36-link-ikon.md
+++ b/source/_patterns/00-atomer/02-lenker/36-link-ikon.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Mobiltelefoner kan utføre telefonoppringinger. [Telefonnummer](http://bradfrostweb.com/blog/mobile/a-tel-tale-sign/) skal derfor være klikkbare, for å spare brukeren for å måtte kopiere og lime inn nummeret. Hva skjer når desktop-brukere klikker på nummeret? Noen enheter (iPad'er ++) spør brukeren om de vil legge nummeret i kontaktlisten sin, andre åpner programmer som Skype, eller liknende.

--- a/source/_patterns/00-atomer/02-lenker/37-link-telefonnummer.md
+++ b/source/_patterns/00-atomer/02-lenker/37-link-telefonnummer.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Mobiltelefoner kan utføre telefonoppringinger. [Telefonnummer](http://bradfrostweb.com/blog/mobile/a-tel-tale-sign/) skal derfor være klikkbare, for å spare brukeren for å måtte kopiere og lime inn nummeret. Hva skjer når desktop-brukere klikker på nummeret? Noen enheter (iPad'er ++) spør brukeren om de vil legge nummeret i kontaktlisten sin, andre åpner programmer som Skype, eller liknende.

--- a/source/_patterns/00-atomer/02-lenker/38-link-mail.md
+++ b/source/_patterns/00-atomer/02-lenker/38-link-mail.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Mobiltelefoner kan utføre telefonoppringinger. [Telefonnummer](http://bradfrostweb.com/blog/mobile/a-tel-tale-sign/) skal derfor være klikkbare, for å spare brukeren for å måtte kopiere og lime inn nummeret. Hva skjer når desktop-brukere klikker på nummeret? Noen enheter (iPad'er ++) spør brukeren om de vil legge nummeret i kontaktlisten sin, andre åpner programmer som Skype, eller liknende.

--- a/source/_patterns/00-atomer/02-lenker/80-hurtignavigasjon-navbar.md
+++ b/source/_patterns/00-atomer/02-lenker/80-hurtignavigasjon-navbar.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Navbar for hurtignavigasjon i en side.

--- a/source/_patterns/00-atomer/02-lenker/_04-♺-link-selvstendig-fare.md
+++ b/source/_patterns/00-atomer/02-lenker/_04-♺-link-selvstendig-fare.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/02-lenker/_99-link-button-download.md
+++ b/source/_patterns/00-atomer/02-lenker/_99-link-button-download.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 ---
 NB: Dette er en variant av  [link.mustache]
 

--- a/source/_patterns/00-atomer/03-knapper/10-knapp.md
+++ b/source/_patterns/00-atomer/03-knapper/10-knapp.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 1
 ---
 Brukes for handlinger, f.eks 'Lagre', 'Send', osv. Siden knappen er kun 36px høy, er det avsatt et område over og under, slik at touch target er 48px. Det skal være minimum 12px mellomrom mellom hver knapp/lenke.

--- a/source/_patterns/00-atomer/03-knapper/11-♺-knapp-suksess.md
+++ b/source/_patterns/00-atomer/03-knapper/11-♺-knapp-suksess.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 NB: Dette er en variant av [knapp.mustache]

--- a/source/_patterns/00-atomer/03-knapper/12-♺-knapp-fare.md
+++ b/source/_patterns/00-atomer/03-knapper/12-♺-knapp-fare.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 NB: Dette er en variant av [knapp.mustache]

--- a/source/_patterns/00-atomer/03-knapper/13-♺-knapp-deaktivert.md
+++ b/source/_patterns/00-atomer/03-knapper/13-♺-knapp-deaktivert.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 NB: Dette er en variant av [knapp.mustache]

--- a/source/_patterns/00-atomer/03-knapper/14-♺-knapp-stor.md
+++ b/source/_patterns/00-atomer/03-knapper/14-♺-knapp-stor.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 NB: Dette er en variant av [knapp.mustache]

--- a/source/_patterns/00-atomer/03-knapper/15-♺-knapp-link.md
+++ b/source/_patterns/00-atomer/03-knapper/15-♺-knapp-link.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 NB: Dette er en variant av [knapp.mustache]

--- a/source/_patterns/00-atomer/03-knapper/16-♺-knapp-link-fare.md
+++ b/source/_patterns/00-atomer/03-knapper/16-♺-knapp-link-fare.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 NB: Dette er en variant av [knapp.mustache]

--- a/source/_patterns/00-atomer/03-knapper/25-knapp-ikon-tekst.md
+++ b/source/_patterns/00-atomer/03-knapper/25-knapp-ikon-tekst.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/03-knapper/28-♺-knapp-ikon-tekst-gjennomsiktig-hvit.md
+++ b/source/_patterns/00-atomer/03-knapper/28-♺-knapp-ikon-tekst-gjennomsiktig-hvit.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/03-knapper/30-♺-knapp-ikon-tekst-skygge-utvidet.md
+++ b/source/_patterns/00-atomer/03-knapper/30-♺-knapp-ikon-tekst-skygge-utvidet.md
@@ -1,5 +1,5 @@
 ---
- state: specification
+ state: specification altinn
  version: 0
 ---
 

--- a/source/_patterns/00-atomer/03-knapper/30-♺-knapp-ikon-tekst-skygge.md
+++ b/source/_patterns/00-atomer/03-knapper/30-♺-knapp-ikon-tekst-skygge.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/03-knapper/31-knapp-fremhevet-stor.md
+++ b/source/_patterns/00-atomer/03-knapper/31-knapp-fremhevet-stor.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: cardsToggle.js, truncateLines.js
 ---

--- a/source/_patterns/00-atomer/04-handlingsknapper/10-knapp-ikon.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/10-knapp-ikon.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/04-handlingsknapper/11-♺-knapp-ikon-med-popover.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/11-♺-knapp-ikon-med-popover.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: popover.js
 ---

--- a/source/_patterns/00-atomer/04-handlingsknapper/17-handlingsknapp.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/17-handlingsknapp.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn altinnett
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/04-handlingsknapper/18-♺-handlingsknapp-variasjoner.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/18-♺-handlingsknapp-variasjoner.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/04-handlingsknapper/19-♺-handlingsknapp-full-bredde.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/19-♺-handlingsknapp-full-bredde.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/04-handlingsknapper/20-♺-handlingsknapp-ekspanderbart-innhold.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/20-♺-handlingsknapp-ekspanderbart-innhold.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 js: expandContent.js
 ---

--- a/source/_patterns/00-atomer/04-handlingsknapper/21-handlingsknapp-stor.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/21-handlingsknapp-stor.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Brukes i tilfeller der brukeren kan legge til noe, f.eks: en en person, virksomhet, etc.

--- a/source/_patterns/00-atomer/04-handlingsknapper/23-knapp-veksle.md
+++ b/source/_patterns/00-atomer/04-handlingsknapper/23-knapp-veksle.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: toggleSwitch.js
 ---

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/01-popover.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/01-popover.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 js: popover.js
 ---

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/02-tooltip.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/02-tooltip.md
@@ -1,5 +1,4 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 1
 ---
-

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/03-footnote.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/03-footnote.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 0
 ---
 Lorem ipsum...

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/10-ekspanderbar-overskrift.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/10-ekspanderbar-overskrift.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: toggleFilter.js
 ---

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/25-ekspanderbar-knapp.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/25-ekspanderbar-knapp.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/26-ekspanderbar-tekst.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/26-ekspanderbar-tekst.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: toggleFilter.js
 ---

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/27-ekspanderbar-tittel.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/27-ekspanderbar-tittel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: toggleFilter.js
 ---

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/29-♺-ekspanderbar-tittel-med-underlinje.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/29-♺-ekspanderbar-tittel-med-underlinje.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/32-link-med-popover-ikon.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/32-link-med-popover-ikon.md
@@ -1,7 +1,6 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 1
 js: popover.js
 ---
 Brukes når tips skal gis brukeren idet han trykker. Popover har tre fargevarianter. Gul er standard informasjon, grønn brukes for å bekrefte/oppfordre til handling, rød brukes for å advare.
-

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/33-♺-link-med-popover-fargevariasjoner.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/33-♺-link-med-popover-fargevariasjoner.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Brukes når tips skal gis brukeren idet han trykker. Popover har tre fargevarianter. Gul er standard informasjon, grønn brukes for å bekrefte/oppfordre til handling, rød brukes for å advare.

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/34-♺-link-med-stor-popover-ikon.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/34-♺-link-med-stor-popover-ikon.md
@@ -1,4 +1,4 @@
 ---
-state: needsrevalidation archived
+state: archived altinn
 version: 1
 ---

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/35-knapp-med-popover.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/35-knapp-med-popover.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 En knapp stylet som en lenke, som viser popover. Refererer til knapp ikon for å forhindre duplisering av kode

--- a/source/_patterns/00-atomer/05-Ekspansjonsknapper/38-link-hjelpefunksjon.md
+++ b/source/_patterns/00-atomer/05-Ekspansjonsknapper/38-link-hjelpefunksjon.md
@@ -1,4 +1,4 @@
 ---
-state: needsrevalidation archived
+state: archived altinn
 version: 1
 ---

--- a/source/_patterns/00-atomer/06-tabeller/05-tabell-regnestykke.md
+++ b/source/_patterns/00-atomer/06-tabeller/05-tabell-regnestykke.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn altinnett
 version: 0
 ---
 Brukes for å vise regnestykker

--- a/source/_patterns/00-atomer/06-tabeller/10-tabell-responsiv.md
+++ b/source/_patterns/00-atomer/06-tabeller/10-tabell-responsiv.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 Brukes kun for å vise tabulære data.

--- a/source/_patterns/00-atomer/07-tekst/00-varsel.md
+++ b/source/_patterns/00-atomer/07-tekst/00-varsel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Brukes for å varsle brukeren om noe. Et varsel hører som regel sammen med en annen komponent. Varselene kan for eksempel høre sammen med input-felt, der brukeren får en feilmelding dersom utfyllt informasjon ikke er korrekt. Denne har nå støtte for flere elementer i varselet, tekst, ikon og lenke.

--- a/source/_patterns/00-atomer/07-tekst/01-♺-varsel-01-info.md
+++ b/source/_patterns/00-atomer/07-tekst/01-♺-varsel-01-info.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/01-♺-varsel-02-advarsel.md
+++ b/source/_patterns/00-atomer/07-tekst/01-♺-varsel-02-advarsel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/01-♺-varsel-03-godkjent.md
+++ b/source/_patterns/00-atomer/07-tekst/01-♺-varsel-03-godkjent.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/01-♺-varsel-04-alene.md
+++ b/source/_patterns/00-atomer/07-tekst/01-♺-varsel-04-alene.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/01-♺-varsel-05-utenskygge.md
+++ b/source/_patterns/00-atomer/07-tekst/01-♺-varsel-05-utenskygge.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/01-♺-varsel-06-fullbredde.md
+++ b/source/_patterns/00-atomer/07-tekst/01-♺-varsel-06-fullbredde.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/02-intro-tekst.md
+++ b/source/_patterns/00-atomer/07-tekst/02-intro-tekst.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 Brukes som første avsnitt i artikler.

--- a/source/_patterns/00-atomer/07-tekst/03-avsnitt.md
+++ b/source/_patterns/00-atomer/07-tekst/03-avsnitt.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 Vanlig avsnitt.

--- a/source/_patterns/00-atomer/07-tekst/04-merkelapp.md
+++ b/source/_patterns/00-atomer/07-tekst/04-merkelapp.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Brukes for å tiltrekke oppmerksomhet, belyse noe, fortelle at noe er nytt, fortelle antall, etc. F.eks antall uleste eposter. Todo: Lag regler for når de ulike bakgrunnsfargene skal benyttes...

--- a/source/_patterns/00-atomer/07-tekst/04-♺-merkelapp-variasjoner.md
+++ b/source/_patterns/00-atomer/07-tekst/04-♺-merkelapp-variasjoner.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/05-sitat.md
+++ b/source/_patterns/00-atomer/07-tekst/05-sitat.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/06-dato.md
+++ b/source/_patterns/00-atomer/07-tekst/06-dato.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 ---
 
 Mangler retningslinjer.

--- a/source/_patterns/00-atomer/07-tekst/09-sidetittel.md
+++ b/source/_patterns/00-atomer/07-tekst/09-sidetittel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 ---
 
 Brukes for å vise tittelen på siden.

--- a/source/_patterns/00-atomer/07-tekst/10-seksjonstittel.md
+++ b/source/_patterns/00-atomer/07-tekst/10-seksjonstittel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 ---
 
 Brukes for å vise tittelen på seksjonen.

--- a/source/_patterns/00-atomer/07-tekst/11-undertittel.md
+++ b/source/_patterns/00-atomer/07-tekst/11-undertittel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/12-snakkeboble.md
+++ b/source/_patterns/00-atomer/07-tekst/12-snakkeboble.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Brukes i chat

--- a/source/_patterns/00-atomer/07-tekst/20-byline.md
+++ b/source/_patterns/00-atomer/07-tekst/20-byline.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/07-tekst/40-innlogget.md
+++ b/source/_patterns/00-atomer/07-tekst/40-innlogget.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version:  1
 ---
 

--- a/source/_patterns/00-atomer/08-lister/05-liste-nummerert.md
+++ b/source/_patterns/00-atomer/08-lister/05-liste-nummerert.md
@@ -1,0 +1,6 @@
+---
+state: indesignreview altinn
+version: 1
+---
+
+Foreløpig ingen retningslinjer.

--- a/source/_patterns/00-atomer/08-lister/06-liste-nummerert-sirkel.md
+++ b/source/_patterns/00-atomer/08-lister/06-liste-nummerert-sirkel.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/08-lister/07-♺-liste-nummerert-sirkel-gul.md
+++ b/source/_patterns/00-atomer/08-lister/07-♺-liste-nummerert-sirkel-gul.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Nummerert liste med gule punkter

--- a/source/_patterns/00-atomer/08-lister/08-liste-unummerert-sammenkoblet.md
+++ b/source/_patterns/00-atomer/08-lister/08-liste-unummerert-sammenkoblet.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/08-lister/10-liste-unummerert-ikoner.md
+++ b/source/_patterns/00-atomer/08-lister/10-liste-unummerert-ikoner.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/08-lister/11-liste-unummerert-kuler.md
+++ b/source/_patterns/00-atomer/08-lister/11-liste-unummerert-kuler.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/00-atomer/09-bilder-og-media/01-logo.md
+++ b/source/_patterns/00-atomer/09-bilder-og-media/01-logo.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Logoen er en SVG-fil, som sikrer at den vil vise skarpt uansett skjermoppløsning og eventuell innzooming. En PNG fallback benyttes for nettleseres som ikke støtter SVG. Les mer på: [Brad Frost sin blogg.](http://bradfrostweb.com/blog/mobile/hi-res-optimization/)

--- a/source/_patterns/00-atomer/09-bilder-og-media/07-laster-inn.md
+++ b/source/_patterns/00-atomer/09-bilder-og-media/07-laster-inn.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 1
 ---
 Venter på design

--- a/source/_patterns/00-atomer/09-bilder-og-media/15-ikon.md
+++ b/source/_patterns/00-atomer/09-bilder-og-media/15-ikon.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 ikon bruker nå fort awesome. fa er endret til ai for å ikke komme i konflikt med font-awesome.

--- a/source/_patterns/00-atomer/09-bilder-og-media/17-♺-ikon-variasjoner.md
+++ b/source/_patterns/00-atomer/09-bilder-og-media/17-♺-ikon-variasjoner.md
@@ -1,4 +1,4 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---

--- a/source/_patterns/00-atomer/09-bilder-og-media/20-prosentbar.md
+++ b/source/_patterns/00-atomer/09-bilder-og-media/20-prosentbar.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Viser hvor mye som gjenstår av en verdi.

--- a/source/_patterns/01-molekyler/00-tekst/01-person-privat.md
+++ b/source/_patterns/01-molekyler/00-tekst/01-person-privat.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/01-molekyler/00-tekst/02-♺-person-privat-status.md
+++ b/source/_patterns/01-molekyler/00-tekst/02-♺-person-privat-status.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/01-molekyler/00-tekst/03-person-rolle.md
+++ b/source/_patterns/01-molekyler/00-tekst/03-person-rolle.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Brukes som overskrift for å vise hvilken person man redigererer rettigheter til.

--- a/source/_patterns/01-molekyler/00-tekst/05-sammenligning-header.md
+++ b/source/_patterns/01-molekyler/00-tekst/05-sammenligning-header.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/06-sammenligningselement.md
+++ b/source/_patterns/01-molekyler/00-tekst/06-sammenligningselement.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/07-lenketittel-med-forklaring.md
+++ b/source/_patterns/01-molekyler/00-tekst/07-lenketittel-med-forklaring.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/20-prosentbar-med-info.md
+++ b/source/_patterns/01-molekyler/00-tekst/20-prosentbar-med-info.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/30-ikon-tekst.md
+++ b/source/_patterns/01-molekyler/00-tekst/30-ikon-tekst.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/31-♺-ikon-tekst-ekstratittel.md
+++ b/source/_patterns/01-molekyler/00-tekst/31-♺-ikon-tekst-ekstratittel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/32-♺-ikon-tekst-skygge.md
+++ b/source/_patterns/01-molekyler/00-tekst/32-♺-ikon-tekst-skygge.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/33-♺-ikon-tekst-bakgrunn.md
+++ b/source/_patterns/01-molekyler/00-tekst/33-♺-ikon-tekst-bakgrunn.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/34-♺-ikon-tekst-bakgrunn-uten-sirkel.md
+++ b/source/_patterns/01-molekyler/00-tekst/34-♺-ikon-tekst-bakgrunn-uten-sirkel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/36-ikon-tittel.md
+++ b/source/_patterns/01-molekyler/00-tekst/36-ikon-tittel.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/38-sidetittel-byline.md
+++ b/source/_patterns/01-molekyler/00-tekst/38-sidetittel-byline.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/40-ikon-link.md
+++ b/source/_patterns/01-molekyler/00-tekst/40-ikon-link.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/41-♺-ikon-link-ekstratittel.md
+++ b/source/_patterns/01-molekyler/00-tekst/41-♺-ikon-link-ekstratittel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/42-♺-ikon-link-skygge.md
+++ b/source/_patterns/01-molekyler/00-tekst/42-♺-ikon-link-skygge.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/43-♺-ikon-link-skygge-ekstratittel.md
+++ b/source/_patterns/01-molekyler/00-tekst/43-♺-ikon-link-skygge-ekstratittel.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/44-♺-ikon-link-border.md
+++ b/source/_patterns/01-molekyler/00-tekst/44-♺-ikon-link-border.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/46-tekstinnhold-beskrivelse.md
+++ b/source/_patterns/01-molekyler/00-tekst/46-tekstinnhold-beskrivelse.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 Molekyl som inneholder overskrift og beskrivende tekst, flere underoverskrifter og paragraf

--- a/source/_patterns/01-molekyler/00-tekst/60-innboks-header-innhold.md
+++ b/source/_patterns/01-molekyler/00-tekst/60-innboks-header-innhold.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 js: setupTruncateLines.js, togglePanel.js
 ---

--- a/source/_patterns/01-molekyler/00-tekst/61-♺-innboks-header-innhold-ulest.md
+++ b/source/_patterns/01-molekyler/00-tekst/61-♺-innboks-header-innhold-ulest.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 js: togglePanel.js
 ---

--- a/source/_patterns/01-molekyler/00-tekst/62-♺-innboks-header-innhold-lest.md
+++ b/source/_patterns/01-molekyler/00-tekst/62-♺-innboks-header-innhold-lest.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/63-♺-innboks-header-innhold-haster.md
+++ b/source/_patterns/01-molekyler/00-tekst/63-♺-innboks-header-innhold-haster.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/64-♺-innboks-header-innhold-haster-ulest.md
+++ b/source/_patterns/01-molekyler/00-tekst/64-♺-innboks-header-innhold-haster-ulest.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/65-♺-innboks-header-innhold-haster-forfalt.md
+++ b/source/_patterns/01-molekyler/00-tekst/65-♺-innboks-header-innhold-haster-forfalt.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/66-♺-innboks-header-innhold-venter.md
+++ b/source/_patterns/01-molekyler/00-tekst/66-♺-innboks-header-innhold-venter.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/67-♺-innboks-header-innhold-venter-haster.md
+++ b/source/_patterns/01-molekyler/00-tekst/67-♺-innboks-header-innhold-venter-haster.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/68-♺-innboks-header-innhold-kompakt.md
+++ b/source/_patterns/01-molekyler/00-tekst/68-♺-innboks-header-innhold-kompakt.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/69-♺-innboks-header-innhold-videresendt.md
+++ b/source/_patterns/01-molekyler/00-tekst/69-♺-innboks-header-innhold-videresendt.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/00-tekst/75-infotekst-med-border.md
+++ b/source/_patterns/01-molekyler/00-tekst/75-infotekst-med-border.md
@@ -1,0 +1,5 @@
+---
+state: indesignreview altinn
+version: 1
+---
+Foreløpig ingen retningslinjer

--- a/source/_patterns/01-molekyler/00-tekst/80-info-delete-add.md
+++ b/source/_patterns/01-molekyler/00-tekst/80-info-delete-add.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Informasjon til bruk i lister med mulighet for slett og legg til ny.

--- a/source/_patterns/01-molekyler/00-tekst/_45-liste-med-beskrivelse.md
+++ b/source/_patterns/01-molekyler/00-tekst/_45-liste-med-beskrivelse.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 1
 ---
 Molekyl som inneholder liste med overskrift og beskrivende tekst. Hovedsakelig for bruk i popovers. NB: Mulig overflødig.

--- a/source/_patterns/01-molekyler/01-kort/01-kort.md
+++ b/source/_patterns/01-molekyler/01-kort/01-kort.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/01-kort/02-kort-hoved.md
+++ b/source/_patterns/01-molekyler/01-kort/02-kort-hoved.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/01-kort/_04-kort-gjennomgang.md
+++ b/source/_patterns/01-molekyler/01-kort/_04-kort-gjennomgang.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/02-navigasjon/01-trekkspill-overskrifter.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/01-trekkspill-overskrifter.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/01-molekyler/02-navigasjon/02-trekkspill.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/02-trekkspill.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/01-molekyler/02-navigasjon/03-ekspanderbar-info.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/03-ekspanderbar-info.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Molekyl med overskrift og ekspanderbar unummerert liste

--- a/source/_patterns/01-molekyler/02-navigasjon/10-faner-og-knapp.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/10-faner-og-knapp.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn altinnett
 version: 1
 ---
 Et innholdsområdet med flere paneler, hvert panel er forbundet med en overskrift i en liste og en knapp på høyre siden. Kun et panel er synlig om gangen. Fungerer best for 2-4 overskrifter/paneler, ettersom visninge er horisontal, og dermed har begrenset plass på små skjermer.

--- a/source/_patterns/01-molekyler/02-navigasjon/10-faner.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/10-faner.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Et enkelt innholdsområdet med flere paneler, hvert panel er forbundet med en overskrift i en liste. Kun et panel er synlig om gangen. Fungerer best for 2-4 overskrifter/paneler, ettersom visninge er horisontal, og dermed har begrenset plass på små skjermer.

--- a/source/_patterns/01-molekyler/02-navigasjon/11-toppoppgaver.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/11-toppoppgaver.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Brukes for å dele inn ulike typer innhold, foreløpig kun på innboks

--- a/source/_patterns/01-molekyler/02-navigasjon/14-smulesti.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/14-smulesti.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn altinnett
 version: 0
 ---
 Brødsmulesti brukes i toppen av undersider for å vise hvor brukeren står i navigasjonsstien.

--- a/source/_patterns/01-molekyler/02-navigasjon/15-sidenavigering.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/15-sidenavigering.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 Brukes for å dele opp innholdet i adskilte sider man kan navigere mellom. Aktiv side skal alltid være markert.

--- a/source/_patterns/01-molekyler/02-navigasjon/20-hurtignavigasjon.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/20-hurtignavigasjon.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 Liste for hurtignavigasjon i en side. Denne genererer lister med a names man kan navigere til.

--- a/source/_patterns/01-molekyler/02-navigasjon/50-ekspanderbar-liste.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/50-ekspanderbar-liste.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Molekyl med overskrift og ekspanderbar unummerert liste

--- a/source/_patterns/01-molekyler/02-navigasjon/51-♺-ekspanderbar-liste-heading-actions.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/51-♺-ekspanderbar-liste-heading-actions.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 Molekyl med overskrift med høyrejustert tekst og ikon, og ekspanderbar unummerert liste

--- a/source/_patterns/01-molekyler/02-navigasjon/55-ekspanderbar-liste-status.md
+++ b/source/_patterns/01-molekyler/02-navigasjon/55-ekspanderbar-liste-status.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Molekyl med overskrift og ekspanderbar unummerert liste

--- a/source/_patterns/01-molekyler/03-media/00-illustrasjonslenke.md
+++ b/source/_patterns/01-molekyler/03-media/00-illustrasjonslenke.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/03-media/03-bilde-innhold-under.md
+++ b/source/_patterns/01-molekyler/03-media/03-bilde-innhold-under.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/03-media/03-bilde-innhold.md
+++ b/source/_patterns/01-molekyler/03-media/03-bilde-innhold.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn altinnett
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/03-media/06-bilde-sitat.md
+++ b/source/_patterns/01-molekyler/03-media/06-bilde-sitat.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/03-media/10-jumbotron.md
+++ b/source/_patterns/01-molekyler/03-media/10-jumbotron.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/03-media/11-♺-jumbotron-liste.md
+++ b/source/_patterns/01-molekyler/03-media/11-♺-jumbotron-liste.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/03-media/12-♺-jumbotron-artikkel.md
+++ b/source/_patterns/01-molekyler/03-media/12-♺-jumbotron-artikkel.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/03-media/20-artikkel-teaser.md
+++ b/source/_patterns/01-molekyler/03-media/20-artikkel-teaser.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 

--- a/source/_patterns/01-molekyler/04-grupper/00-grupperte-knapper.md
+++ b/source/_patterns/01-molekyler/04-grupper/00-grupperte-knapper.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Når flere knapper skal vises ved siden av hverandre, kan de legges i klassen a-btn-group. Dette gjelder f.eks i tilfeller der brukeren har flere valg/handlingsmuligheter.

--- a/source/_patterns/01-molekyler/04-grupper/01-grupperte-fremhevede-knapper.md
+++ b/source/_patterns/01-molekyler/04-grupper/01-grupperte-fremhevede-knapper.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 js: cardsToggle.js, truncateLines.js
 ---

--- a/source/_patterns/01-molekyler/04-grupper/02-midtstilte-valgknapper-med-tekst.md
+++ b/source/_patterns/01-molekyler/04-grupper/02-midtstilte-valgknapper-med-tekst.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: addRightsTableHandler.js for prototype only
 ---

--- a/source/_patterns/01-molekyler/05-forms/00-last-opp-og-fjern.md
+++ b/source/_patterns/01-molekyler/05-forms/00-last-opp-og-fjern.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/05-forms/01-nestede-avkrysningsbokser.md
+++ b/source/_patterns/01-molekyler/05-forms/01-nestede-avkrysningsbokser.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/05-forms/02-fant-du-det-du-lette-etter.md
+++ b/source/_patterns/01-molekyler/05-forms/02-fant-du-det-du-lette-etter.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 1
 js: feedbackToggle.js
 ---

--- a/source/_patterns/01-molekyler/05-forms/03-valgknapper-og-tekstfelt.md
+++ b/source/_patterns/01-molekyler/05-forms/03-valgknapper-og-tekstfelt.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/05-forms/10-abonner.md
+++ b/source/_patterns/01-molekyler/05-forms/10-abonner.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 js: feedbackToggle.js
 ---

--- a/source/_patterns/01-molekyler/05-lister/00-liste-unummerert.md
+++ b/source/_patterns/01-molekyler/05-lister/00-liste-unummerert.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 js: selectableCheckbox.js
 ---

--- a/source/_patterns/01-molekyler/05-lister/02-♺-liste-unummerert-lenke.md
+++ b/source/_patterns/01-molekyler/05-lister/02-♺-liste-unummerert-lenke.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Implementasjon av liste som støtter variabelt antall rader, kolonner og innhold i kolonnene. Målet er at denne skal erstatte den eksisterende listen, men arbeid på denne pågår enda.

--- a/source/_patterns/01-molekyler/05-lister/10-♺-liste-unummerert-radvarianter.md
+++ b/source/_patterns/01-molekyler/05-lister/10-♺-liste-unummerert-radvarianter.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 1
 js: listRowToggle.js hvis data-list-selectable="true", addListExpandHandler.js hvis data-toggle="collapse", clickableRow.js hvis klasser .a-clickable .a-selectable
 ---

--- a/source/_patterns/01-molekyler/05-lister/20-♺-liste-unummerert-sorterbar.md
+++ b/source/_patterns/01-molekyler/05-lister/20-♺-liste-unummerert-sorterbar.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 js: listSort.js, compareTo.js
 ---

--- a/source/_patterns/01-molekyler/05-lister/_00-liste-ekspanderbart-innhold.md
+++ b/source/_patterns/01-molekyler/05-lister/_00-liste-ekspanderbart-innhold.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Ekspanderbart innhold til liste-radene. Kommer frem ved klikk på raden.

--- a/source/_patterns/01-molekyler/05-lister/_00-liste-innhold.md
+++ b/source/_patterns/01-molekyler/05-lister/_00-liste-innhold.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Innhold til liste-radene.

--- a/source/_patterns/01-molekyler/05-lister/_30-liste-unummerert-uten-popover.md
+++ b/source/_patterns/01-molekyler/05-lister/_30-liste-unummerert-uten-popover.md
@@ -1,5 +1,5 @@
 ---
-state: needsrevalidation
+state: needsrevalidation altinn
 version: 1
 js: listRowToggle.js hvis data-list-selectable="true", addListExpandHandler.js hvis data-toggle="collapse", clickableRow.js hvis klasser .a-clickable .a-selectable
 ---

--- a/source/_patterns/01-molekyler/06-hjelp/00-hjelp-container.md
+++ b/source/_patterns/01-molekyler/06-hjelp/00-hjelp-container.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 0
 ---
 Container med iframe og knapp for stickyhjelp

--- a/source/_patterns/01-molekyler/20-modalelementer/05-modal-header.md
+++ b/source/_patterns/01-molekyler/20-modalelementer/05-modal-header.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/20-modalelementer/10-modal-navbar.md
+++ b/source/_patterns/01-molekyler/20-modalelementer/10-modal-navbar.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/20-modalelementer/15-modal-body-header.md
+++ b/source/_patterns/01-molekyler/20-modalelementer/15-modal-body-header.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/01-molekyler/20-modalelementer/20-ferdigsegment.md
+++ b/source/_patterns/01-molekyler/20-modalelementer/20-ferdigsegment.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/01-globale/00-header.md
+++ b/source/_patterns/02-organismer/01-globale/00-header.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Den globale toppen på siden tar lite plass i høyden, for å holde fokus på innholdet på siden. Headeren tilpasser seg mindre skjermer, og gjemmer menyen under en meny-knapp. Headeren skal være synlig på alle sider på altinn.no.

--- a/source/_patterns/02-organismer/01-globale/01-footer.md
+++ b/source/_patterns/02-organismer/01-globale/01-footer.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 0
 ---
 Footeren inneholder ekstra navigasjonsmuligheter samt kontaktinformasjon. Den tilpasser seg skjermstørrelser. På de minste skjermene legges footer-menypunktene opp i toppmenyen. Footeren skal være synlig på alle sider på altinn.no.

--- a/source/_patterns/02-organismer/01-globale/10-subheader.md
+++ b/source/_patterns/02-organismer/01-globale/10-subheader.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
-Subheader når man ikke skal ha full toppmeny. 
+Subheader når man ikke skal ha full toppmeny.

--- a/source/_patterns/02-organismer/20-forms/10-skjema-innehaver.md
+++ b/source/_patterns/02-organismer/20-forms/10-skjema-innehaver.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Felt for å fylle inn gatenavn og postnummer. Fra attraktivitetsprosjektet, ikke i bruk per nå.

--- a/source/_patterns/02-organismer/20-forms/20-skjema-navn.md
+++ b/source/_patterns/02-organismer/20-forms/20-skjema-navn.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Felt for å fylle inn gatenavn og postnummer. Fra attraktivitetsprosjektet, ikke i bruk per nå.

--- a/source/_patterns/02-organismer/20-forms/30-skjema-adresse.md
+++ b/source/_patterns/02-organismer/20-forms/30-skjema-adresse.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Felt for å fylle inn gatenavn og postnummer. Fra attraktivitetsprosjektet, ikke i bruk per nå.

--- a/source/_patterns/02-organismer/20-forms/40-skjema-dato.md
+++ b/source/_patterns/02-organismer/20-forms/40-skjema-dato.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Felt for å fylle inn gatenavn og postnummer. Fra attraktivitetsprosjektet, ikke i bruk per nå.

--- a/source/_patterns/02-organismer/20-forms/50-skjema-radio.md
+++ b/source/_patterns/02-organismer/20-forms/50-skjema-radio.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Felt for å fylle inn gatenavn og postnummer. Fra attraktivitetsprosjektet, ikke i bruk per nå.

--- a/source/_patterns/02-organismer/20-forms/60-skjema-beskrivelse.md
+++ b/source/_patterns/02-organismer/20-forms/60-skjema-beskrivelse.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 ---
 Felt for å fylle inn gatenavn og postnummer. Fra attraktivitetsprosjektet, ikke i bruk per nå.

--- a/source/_patterns/02-organismer/20-forms/_70-select-profiles.md
+++ b/source/_patterns/02-organismer/20-forms/_70-select-profiles.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 Valg av flere profiler gjennom søk og avkrysning

--- a/source/_patterns/02-organismer/30-seksjoner/01-artikkelliste.md
+++ b/source/_patterns/02-organismer/30-seksjoner/01-artikkelliste.md
@@ -1,6 +1,6 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 
-Bruker rammeverket truncate.js for å legge på ellipsis på linje 2. 
+Bruker rammeverket truncate.js for å legge på ellipsis på linje 2.

--- a/source/_patterns/02-organismer/30-seksjoner/02-artikkelliste-dato.md
+++ b/source/_patterns/02-organismer/30-seksjoner/02-artikkelliste-dato.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 

--- a/source/_patterns/02-organismer/30-seksjoner/03-sammenligning.md
+++ b/source/_patterns/02-organismer/30-seksjoner/03-sammenligning.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 0
 ---
 

--- a/source/_patterns/02-organismer/30-seksjoner/10-grupperte-kort.md
+++ b/source/_patterns/02-organismer/30-seksjoner/10-grupperte-kort.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 

--- a/source/_patterns/02-organismer/30-seksjoner/15-gjennomgang.md
+++ b/source/_patterns/02-organismer/30-seksjoner/15-gjennomgang.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 

--- a/source/_patterns/02-organismer/30-seksjoner/28-chat.md
+++ b/source/_patterns/02-organismer/30-seksjoner/28-chat.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 0
 ---
 

--- a/source/_patterns/02-organismer/30-seksjoner/29-meny-spraakvalg.md
+++ b/source/_patterns/02-organismer/30-seksjoner/29-meny-spraakvalg.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Venter på ikoner.

--- a/source/_patterns/02-organismer/30-seksjoner/30-meny-personbytte.md
+++ b/source/_patterns/02-organismer/30-seksjoner/30-meny-personbytte.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/02-organismer/30-seksjoner/31-personbytte.md
+++ b/source/_patterns/02-organismer/30-seksjoner/31-personbytte.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/02-organismer/30-seksjoner/40-innboks-ingen-treff.md
+++ b/source/_patterns/02-organismer/30-seksjoner/40-innboks-ingen-treff.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/02-organismer/30-seksjoner/80-login-dropdown.md
+++ b/source/_patterns/02-organismer/30-seksjoner/80-login-dropdown.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress altinnett
+state: inprogress altinnett altinn
 version: 1
 ---
 Foreløpig ingen retningslinjer.

--- a/source/_patterns/02-organismer/30-seksjoner/_45-dropdown-overflow.md
+++ b/source/_patterns/02-organismer/30-seksjoner/_45-dropdown-overflow.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Dropdown for innboks sidemeny på mindre skjermer

--- a/source/_patterns/02-organismer/40-artikkel/60-artikkel-start.md
+++ b/source/_patterns/02-organismer/40-artikkel/60-artikkel-start.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn altinnett
 version: 0
 ---
 Sammensatt av brødsmulesti, tittel, ingress og pupliseringsinfo.

--- a/source/_patterns/02-organismer/50-ekspanderbart-panel/05-avanserte-innstillinger.md
+++ b/source/_patterns/02-organismer/50-ekspanderbart-panel/05-avanserte-innstillinger.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 js: togglePanel.js
 ---

--- a/source/_patterns/02-organismer/50-ekspanderbart-panel/30-ekspanderbart-panel.md
+++ b/source/_patterns/02-organismer/50-ekspanderbart-panel/30-ekspanderbart-panel.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 1
 js: togglePanel.js
 ---

--- a/source/_patterns/02-organismer/50-ekspanderbart-panel/31-♺-ekspanderbart-panel-stor.md
+++ b/source/_patterns/02-organismer/50-ekspanderbart-panel/31-♺-ekspanderbart-panel-stor.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 1
 ---
 Brukes i tilfeller der det er ønskelig å gi brukeren oversikt over det som finnes, for deretter å dykke ned i temaer (ved å ekspandere mer informasjon). Kan settes sammen til trekkspill (stor variant), se [trekkspill stort

--- a/source/_patterns/02-organismer/50-ekspanderbart-panel/32-♺-ekspanderbart-panel-element.md
+++ b/source/_patterns/02-organismer/50-ekspanderbart-panel/32-♺-ekspanderbart-panel-element.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Ekspanderbart panel for innboks elementer.

--- a/source/_patterns/02-organismer/50-ekspanderbart-panel/40-ekspanderbart-panel-trekkspill.md
+++ b/source/_patterns/02-organismer/50-ekspanderbart-panel/40-ekspanderbart-panel-trekkspill.md
@@ -1,5 +1,5 @@
 ---
-state: specification
+state: specification altinn
 version: 1
 js: toggleInstant.js
 ---

--- a/source/_patterns/02-organismer/70-Modal-innhold/00-modal-startknapp.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/00-modal-startknapp.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/70-Modal-innhold/01-modal-startknapp-enkeltvindu.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/01-modal-startknapp-enkeltvindu.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn altinnett
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/70-Modal-innhold/10-videresend-i-altinn-tildel-enkeltrettigheter.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/10-videresend-i-altinn-tildel-enkeltrettigheter.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/70-Modal-innhold/11-aktorliste-med-sokefelt.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/11-aktorliste-med-sokefelt.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/70-Modal-innhold/20-se-og-fjern-samtykke.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/20-se-og-fjern-samtykke.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 Organisme for innhold i modal som viser informasjon om et eller flere samtykker og gir mulighet til å slette.

--- a/source/_patterns/02-organismer/70-Modal-innhold/40-onboarding-start.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/40-onboarding-start.md
@@ -1,5 +1,5 @@
 ---
-state: archived
+state: archived altinn
 version: 1
 js: clipboard.js
 ---

--- a/source/_patterns/02-organismer/70-Modal-innhold/8-videresend-i-altinn-melding.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/8-videresend-i-altinn-melding.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/70-Modal-innhold/9-videresend-pa-epost.md
+++ b/source/_patterns/02-organismer/70-Modal-innhold/9-videresend-pa-epost.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/80-Modal-js-innhold/10-kontaktskjema.md
+++ b/source/_patterns/02-organismer/80-Modal-js-innhold/10-kontaktskjema.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/80-Modal-js-innhold/11-kontaktskjema-ferdig.md
+++ b/source/_patterns/02-organismer/80-Modal-js-innhold/11-kontaktskjema-ferdig.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/90-filter/01-filter.md
+++ b/source/_patterns/02-organismer/90-filter/01-filter.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/10-innloggingsinformasjon-innhold.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/10-innloggingsinformasjon-innhold.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/20-varsling-enkelttjenester.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/20-varsling-enkelttjenester.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/30-kvittering-pa-epost.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/30-kvittering-pa-epost.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/40-overfor-SI-bruker.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/40-overfor-SI-bruker.md
@@ -1,5 +1,5 @@
 ---
-state: complete
+state: complete altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/50-datasystemer.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/50-datasystemer.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/60-virksomhetssertifikat.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/60-virksomhetssertifikat.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/61-virksomhetssertifikat-rediger.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/61-virksomhetssertifikat-rediger.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/62-forhandsvalgt-aktor.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/62-forhandsvalgt-aktor.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/70-innboks-panel-innhold.md
+++ b/source/_patterns/02-organismer/_49-ekspanderbart-panel-innhold/70-innboks-panel-innhold.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 1
 ---
 

--- a/source/_patterns/02-organismer/_71-modal-gruppering/01-modal-klientdelegering.md
+++ b/source/_patterns/02-organismer/_71-modal-gruppering/01-modal-klientdelegering.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Modal innhold for klientdelegering

--- a/source/_patterns/02-organismer/_71-modal-gruppering/02-modal-andre-med-rettigheter.md
+++ b/source/_patterns/02-organismer/_71-modal-gruppering/02-modal-andre-med-rettigheter.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn
 version: 1
 ---
 Modal-gruppering for andre med rettigheter

--- a/source/_patterns/02-organismer/_71-modal-gruppering/03-modal-kvittering.md
+++ b/source/_patterns/02-organismer/_71-modal-gruppering/03-modal-kvittering.md
@@ -1,5 +1,5 @@
 ---
-state: inprogress
+state: inprogress altinn
 version: 0
 ---
 

--- a/source/_patterns/03-maler-portal/91-modal/01-modal.md
+++ b/source/_patterns/03-maler-portal/91-modal/01-modal.md
@@ -1,5 +1,5 @@
 ---
-state: indesignreview
+state: indesignreview altinn altinnett
 version: 1
 ---
 Generell mal for alle modaler. Innhold bør grupperes i egne patterns (se organisme for klientdelegering for eksempel) og visning styres med boolske verdier.


### PR DESCRIPTION
I added "altinn" as state in the md-file for all altinn components, so they will not show up in altinnett or brsys unless they are activated. This is done because when all the components showed in Altinnett, some of them looked broken because css/js was not included in the project. It is probably better that each project find what component they want to use from altinn, and then activate the component for their own project by adding their projectname (for example "brsys") to the state in the md-file. So an md-file could for example look like this: 

---
state: complete altinn brsys
version: 1
---

... and the component will then be visible on altinn and brsys all-page, but not for altinnett.

Sounds ok?