### PR TITLE
Added css, title attribute to show long names as ellipsis

### DIFF
--- a/source/_patterns/00-atomer/03-knapper/25-knapp-ikon-tekst.mustache
+++ b/source/_patterns/00-atomer/03-knapper/25-knapp-ikon-tekst.mustache
@@ -5,6 +5,7 @@
   {{# data-action }} data-action="{{data-action}}" {{/ data-action }}
   {{# data-url }} data-url="{{{data-url}}}" {{/ data-url }}
   {{# data-target }} data-target="#{{ data-target }}" aria-controls="{{ data-target }}" {{/ data-target }}
+  {{# title }} title="{{ title }}" {{/ title }}
   >
 
   {{# button-icon }}

--- a/source/_patterns/01-molekyler/00-tekst/03-person-rolle.mustache
+++ b/source/_patterns/01-molekyler/00-tekst/03-person-rolle.mustache
@@ -8,7 +8,7 @@
       {{> atomer-ikon }}
     </div>
   {{/ user-icon }}
-  <div class="a-personRole-text">
+  <div class="a-personRole-text" title="{{ person-role-name }}">
     <span class="a-personRole-role">{{ person-role-role }}</span>
     <span class="a-personRole-name">{{{ person-role-name }}}</span>
     {{# person-role-name-meta }}

--- a/source/_patterns/01-molekyler/05-lister/_00-liste-innhold.mustache
+++ b/source/_patterns/01-molekyler/05-lister/_00-liste-innhold.mustache
@@ -1,6 +1,6 @@
 {{# column-items }}
   {{# column-text }}
-    {{# classes }} <span class="{{ classes }}"> {{/ classes }}
+    {{# classes }} <span class="{{ classes }}" {{# title }} title="{{ title }}"{{/ title }}> {{/ classes }}
     {{{ text }}}
     {{# classes }} </span> {{/ classes }}
     {{# text-extra }}

--- a/source/_patterns/02-organismer/30-seksjoner/30-meny-personbytte.json
+++ b/source/_patterns/02-organismer/30-seksjoner/30-meny-personbytte.json
@@ -163,6 +163,27 @@
     },
     {
       "button-main": {
+        "button-class": "a-btn-shadow-large a-btn a-btn-shadow a-btn-icon a-bgGreyLight",
+        "button-colorClass": "",
+        "button-dot": false,
+        "button-text": "Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "button-textClass": "a-fontBold",
+        "button-text-second": {
+          "button-text-second": "Personnr. 123456 12344",
+          "button-text-second-class": "a-fontReg a-fontSizeXS"
+        },
+        "button-icon": {
+          "icon-prefix": "ai",
+          "icon-class": "ai-private ai-left",
+          "icon-extra-class": ""
+        },
+        "title":"Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "link-url": "link.sider-portal-innboks"
+      },
+      "button-sub": false
+    },
+    {
+      "button-main": {
         "button-class": " a-btn-shadow-large a-btn a-btn-shadow a-btn-icon",
         "button-colorClass": "",
         "button-dot": false,

--- a/source/_patterns/02-organismer/30-seksjoner/31-personbytte.json
+++ b/source/_patterns/02-organismer/30-seksjoner/31-personbytte.json
@@ -130,6 +130,27 @@
     },
     {
       "button-main": {
+        "button-class": "a-btn-shadow-large a-btn a-btn-shadow a-btn-icon a-bgGreyLight",
+        "button-colorClass": "",
+        "button-dot": false,
+        "button-text": "Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "button-textClass": "a-fontBold",
+        "button-text-second": {
+          "button-text-second": "Personnr. 123456 12344",
+          "button-text-second-class": "a-fontReg a-fontSizeXS"
+        },
+        "button-icon": {
+          "icon-prefix": "ai",
+          "icon-class": "ai-private ai-left",
+          "icon-extra-class": ""
+        },
+        "title":"Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "link-url": "link.sider-portal-innboks"
+      },
+      "button-sub": false
+    },
+    {
+      "button-main": {
         "button-class": " a-btn-shadow-large a-btn a-btn-shadow a-btn-icon",
         "button-colorClass": "",
         "button-dot": false,

--- a/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg.json
+++ b/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg.json
@@ -153,6 +153,27 @@
     },
     {
       "button-main": {
+        "button-class": "a-btn-shadow-large a-btn a-btn-shadow a-btn-icon a-bgGreyLight",
+        "button-colorClass": "",
+        "button-dot": false,
+        "button-text": "Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "button-textClass": "a-fontBold",
+        "button-text-second": {
+          "button-text-second": "Personnr. 123456 12344",
+          "button-text-second-class": "a-fontReg a-fontSizeXS"
+        },
+        "button-icon": {
+          "icon-prefix": "ai",
+          "icon-class": "ai-private ai-left",
+          "icon-extra-class": ""
+        },
+        "title":"Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "link-url": "link.sider-portal-innboks"
+      },
+      "button-sub": false
+    },
+    {
+      "button-main": {
         "button-class": " a-btn-shadow-large a-btn a-btn-shadow a-btn-icon",
         "button-colorClass": "",
         "button-dot": false,

--- a/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg~forste-gang.json
+++ b/source/_patterns/04-sider-portal/01-aktorvalg/10-aktorvalg~forste-gang.json
@@ -155,6 +155,27 @@
     },
     {
       "button-main": {
+        "button-class": "a-btn-shadow-large a-btn a-btn-shadow a-btn-icon a-bgGreyLight",
+        "button-colorClass": "",
+        "button-dot": false,
+        "button-text": "Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "button-textClass": "a-fontBold",
+        "button-text-second": {
+          "button-text-second": "Personnr. 123456 12344",
+          "button-text-second-class": "a-fontReg a-fontSizeXS"
+        },
+        "button-icon": {
+          "icon-prefix": "ai",
+          "icon-class": "ai-private ai-left",
+          "icon-extra-class": ""
+        },
+        "title":"Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
+        "link-url": "link.sider-portal-innboks"
+      },
+      "button-sub": false
+    },
+    {
+      "button-main": {
         "button-class": " a-btn-shadow-large a-btn a-btn-shadow a-btn-icon",
         "button-colorClass": "",
         "button-dot": false,

--- a/source/_patterns/04-sider-portal/50-innboks/00-innboks.json
+++ b/source/_patterns/04-sider-portal/50-innboks/00-innboks.json
@@ -194,6 +194,7 @@
           "button-colorClass": "",
           "link-url": "link.sider-portal-innboks-mva-og-skatt-nyoppstartet",
           "button-text": "Mattilsynet + Til utfylling",
+          "title": "Mattilsynet + Til utfylling",
           "responsive-br": true,
           "char-icon": {
             "char": "M"

--- a/source/_patterns/04-sider-portal/50-innboks/03-videresend-i-altinn.json
+++ b/source/_patterns/04-sider-portal/50-innboks/03-videresend-i-altinn.json
@@ -77,14 +77,15 @@
               ]
             },
             {
-              "additional-classes": "hidden-sm-down col-md-5",
+              "additional-classes": "hidden-sm-down col-md-5 col-lg-3 a-role-name",
               "onclick": false,
               "searchable": true,
+              "title": "Daglig leder/Administrerende Direktør",
               "column-items": [
                 {
                   "column-text": {
                     "classes": "a-js-sortValue",
-                    "text": "Daglig leder"
+                    "text": "Daglig leder/Administrerende Direktør"
                   }
                 }
               ]

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
@@ -38,7 +38,7 @@
     "show-gi-fjerne-roller": {
       "person-rolle": {
         "person-role-role": "Styremedlem",
-        "person-role-name": "Jan Derek Sørensen",
+        "person-role-name": "Jan Derek Sørensen Julius Andreas Gimli Arn MacGyver Chewbacka Highlander Elessar-Jankov",
         "icon-class": "ai-private",
         "icon-extra-class": ""
       },

--- a/source/css/scss-altinn/objects/_blocks.scss
+++ b/source/css/scss-altinn/objects/_blocks.scss
@@ -45,6 +45,9 @@
 
   .a-personRole-text {
     float: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     .a-personRole-role {
       @include a-fontSize12;
@@ -62,6 +65,14 @@
   .a-label {
     margin-top: -2px;
   }
+}
+
+//Role Name
+.a-role-name {
+  float: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 // Filter guide

--- a/source/css/scss-common/objects/_buttons.scss
+++ b/source/css/scss-common/objects/_buttons.scss
@@ -175,7 +175,10 @@
   }
 
   .a-btn-icon-text {
+    overflow: hidden;
     text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     align-self: center;
   }
 


### PR DESCRIPTION
The following pages are tested for the long name scenario
1) Videresend i Altinn - The role names can be long. This is fixed with css 'a-role-name' but the title doesn't seem to be displaying on hovering.
2) Innboks - Search names in the side panel is fixed. Tooltip is displayed on hover
3) Profil - Andre med rettigheter- Gi og fjerne rettigheter
    long names fixed
4) Change Person - Lite aktørvalg
     - Person name in list
     -  Current person name


