### PR TITLE
Removing class from siblings upon expanding a list item

### DIFF
--- a/source/js/production/modules/addListExpandHandler.js
+++ b/source/js/production/modules/addListExpandHandler.js
@@ -4,6 +4,7 @@ var addListExpandHandler = function() {
     // present even though the content is about to be expanded
     if ($(this).hasClass('collapsed')) {
       $(this).closest('li').addClass('a-expanded');
+      $(this).closest('li').siblings().removeClass('a-expanded');
     } else {
       $(this).closest('li').removeClass('a-expanded');
     }


### PR DESCRIPTION
Removing 'a-expanded' from siblings upon expanding a list item. This was previously not removed correctly, resulting in the "Utvid"/"Lukk" label not changing as expected.