### PR TITLE
Moved the ellipsis styles to the a-personRole-name class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-designsystem",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "Altinn Design system based on Pattern Lab.",
   "keywords": [
     "Altinn",

--- a/source/css/scss-altinn/objects/_blocks.scss
+++ b/source/css/scss-altinn/objects/_blocks.scss
@@ -46,12 +46,6 @@
   .a-personRole-text {
     float: left;
     width: 80%;
-    @include media-breakpoint-up( lg ) {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      word-break: normal;
-      white-space: nowrap;
-    }
 
     .a-personRole-role {
       @include a-fontSize12;
@@ -63,6 +57,14 @@
     .a-personRole-name {
       @include a-fontSize20;
       @include a-fontBold;
+      display: block;
+
+      @include media-breakpoint-up( lg ) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        word-break: normal;
+        white-space: nowrap;
+      }
     }
   }
 


### PR DESCRIPTION
Moved the ellipsis styles from parent to the specific class for role name so that it works when the role name is within a child container also. 