### PR TITLE
Matsgm/19686 replaced svg checkmark in checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-designsystem",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Altinn Design system based on Pattern Lab.",
   "keywords": [
     "Altinn",

--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -550,12 +550,12 @@ textarea {
       }
 
       &::after {
-        top: 3px;
+        top: 2px;
         left: 9px;
-        width: 7px;
-        height: 14px;
+        width: 0.7rem;
+        height: 1.6rem;
         border: solid $black;
-        border-width: 0 3px 4px 0;
+        border-width: 0 3px 5px 0;
         transform: rotate(45deg);
       }
     }

--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -550,13 +550,13 @@ textarea {
       }
 
       &::after {
-        top: 1px;
-        left: 2px;
-        width: 2rem;
-        height: 2rem;
-        background-color: $white;
-        background-image: url($images-base-url + 'checkbox-checked.svg');
-        background-size: 100%;
+        top: 3px;
+        left: 9px;
+        width: 7px;
+        height: 14px;
+        border: solid $black;
+        border-width: 0 3px 4px 0;
+        transform: rotate(45deg);
       }
     }
 


### PR DESCRIPTION
Fixed bug in IE11 where SVG image is not shown outside the "container" where the CSS class is applied.

Replaced the SVG checkmark in checked checkbox with 45 degrees rotated right/bottom borders, and resized and moved to fit in checkbox. Tested in IE11 and Chrome.

Bumped version number in package.json.