### PR TITLE
New package-lock.json because bumped version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-designsystem",
-  "version": "2.0.6",
+  "version": "2.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
New package-lock.json because bumped version.