### PR TITLE
Fixed missing css display in .a-visibleWhenCompleted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-designsystem",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-designsystem",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Altinn Design system based on Pattern Lab.",
   "keywords": [
     "Altinn",

--- a/source/css/scss-common/base/_global-classes.scss
+++ b/source/css/scss-common/base/_global-classes.scss
@@ -476,6 +476,10 @@ hr {
 
     .a-visibleWhenCompleted {
       display: inline-block;
+
+      @include media-breakpoint-up( sm ) {
+        display: inline-block !important;
+      }
     }
   }
 


### PR DESCRIPTION
During commit to master #198 there was one missing "display" in CSS.
The text "added/lagt til" was not shown when adding roles.