### PR TITLE
Fixed form check sizing for a-form-checkboxes--discreet.

### DIFF
--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -587,8 +587,10 @@ textarea {
       &:checked~.custom-control-label {
         &::after {
           top: 2px;
-          width: 1.4rem;
-          height: 1.4rem;
+          left: 6px;
+          width: 0.6rem;
+          height: 1.3rem;
+          border-width: 0 2px 4px 0;
         }
       }
     }


### PR DESCRIPTION
Fixed smaller "discreet" checkboxes getting correct sized "checkmarks" with a-form-checkboxes--discree class.