### PR TITLE
Tjenestesøk med ServiceOwner kolonne + Oppdatering av 'Ny lokal rolle' til det nye designet

### DIFF
--- a/config/gulp/config.json
+++ b/config/gulp/config.json
@@ -316,6 +316,7 @@
             "source/js/prototyping/modules/preOpenModals.js",
             "source/js/prototyping/modules/prototypingInteractionStarteENK.js",            
             "source/js/prototyping/modules/searchWithAutoComplete.js",
+            "source/js/prototyping/modules/searchWithAutoCompleteVarselEnkeltTjeneste.js",
             "source/js/prototyping/modules/searchWithMultipleSelectInAutoComplete.js",
             "source/js/prototyping/modules/searchWithHighlight.js",
             "source/js/prototyping/modules/selectAll.js",

--- a/source/_patterns/00-atomer/01-forms/10-tekst-input.mustache
+++ b/source/_patterns/00-atomer/01-forms/10-tekst-input.mustache
@@ -80,7 +80,7 @@
 
     </div>
     {{# autocomplete }}
-      <div class="a-autocomplete-container d-none d-sm-block">
+      <div class="a-autocomplete-container d-none d-block">
       </div>
     {{/ autocomplete}}
 

--- a/source/_patterns/02-organismer/70-Modal-innhold/_93-delegering-roller.json
+++ b/source/_patterns/02-organismer/70-Modal-innhold/_93-delegering-roller.json
@@ -3,7 +3,7 @@
   "button-text": "En knapp stylet som en link som antyder fare",
   "button-class": "a-btn-link a-linkDanger float-right",
   "display-as-link": true,
-  "search-title": "Søk:",
+  "search-title": "Gi nye rettigheter",
   "person-rolle": true,
   "search-rights": true,
   "top-label": "Søk",

--- a/source/_patterns/02-organismer/70-Modal-innhold/_93-delegering-roller.mustache
+++ b/source/_patterns/02-organismer/70-Modal-innhold/_93-delegering-roller.mustache
@@ -12,7 +12,7 @@
     </div>
     {{/ showButton }}
   </div>
-  {{# search-rights }}
+  {{# service-search }}
   <div class="row">
     <div class="col-12 col-lg-6 mt-4">
       <div class="a-textSizeS a-fontBold{{# isInactive }} a-dimText3{{/ isInactive }}">
@@ -25,7 +25,23 @@
       {{> atomer-tekst-input }}
     </div>
   </div>
-  {{/ search-rights }}
+  {{/ service-search }}
+  {{# search-header }}
+  <div class="row">
+    <div class="col-12">
+      <h3 class="a-fontReg a-fontSizeL mt-2">
+        {{ search-header }}
+      </h3>
+    </div>
+  </div>
+  {{/ search-header }}
+  {{# search-result }}
+    <div class="row">
+      <div class="col-12">
+        {{> molekyler-liste-unummerert }}
+      </div>
+    </div>
+  {{/ search-result }}
 
   {{# expandable-list }}
     <div class="row">

--- a/source/_patterns/04-sider-portal/60-profil-roller-rettigheter/01-profil-roller-rettigheter.json
+++ b/source/_patterns/04-sider-portal/60-profil-roller-rettigheter/01-profil-roller-rettigheter.json
@@ -2272,7 +2272,7 @@
           ],
           "icon-extra-class": ""
         },
-        "form-control-class": "a-js-autocomplete",
+        "form-control-class": "a-js-autocomplete-varsel",
         "autocomplete": true
       },
       "tjeneste-liste": {
@@ -2294,6 +2294,43 @@
         "header": false,
         "rows": [
           {
+            "id": "hiddenMalRow",
+            "additional-classes": "a-dotted a-success a-danger a-selected a-selectable a-hiddenRow",
+            "tabable": true,
+            "role": "button",
+            "columns": [
+              {
+                "additional-classes": "col",
+                "column-items": [
+                  {
+                    "column-text": {
+                      "text": "RF-0009 Kompensasjon av merverdiavgift for kommuner og fylkeskommuner mv.."
+                    }
+                  },
+                  {
+                    "column-text": {
+                      "classes": "sr-only",
+                      "text": "Trykk for å slette varsel"
+                    }
+                  }
+                ]
+              },
+              {
+                "additional-classes": "text-right col-auto",
+                "column-items": [
+                  {
+                    "column-icon": {
+                      "icon-prefix": "ai",
+                      "icon-class": "ai-circle-exit",
+                      "icon-extra-class": "a-danger"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "firstRow",
             "additional-classes": "a-dotted a-success a-danger a-selected a-selectable",
             "tabable": true,
             "role": "button",
@@ -2329,6 +2366,7 @@
             ]
           },
           {
+            "id": "secondRow",
             "additional-classes": "a-dotted a-selectable a-selected a-danger",
             "tabable": true,
             "role": "button",
@@ -2373,6 +2411,7 @@
             "expandable-section": false
           },
           {
+            "id": "thirdRow",
             "additional-classes": "a-dotted a-success a-danger a-selected a-selectable",
             "tabable": true,
             "role": "button",
@@ -2408,6 +2447,7 @@
             ]
           },
           {
+            "id": "fourthRow",
             "additional-classes": "a-dotted a-success a-danger a-selected a-selectable",
             "tabable": true,
             "role": "button",

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~egendefinert-rolle-rediger.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~egendefinert-rolle-rediger.json
@@ -1,879 +1,1006 @@
-  {
-    "variation-class": "a-iconText-background a-iconText-large",
-    "hasIcon": {
-      "icon-prefix": "ai",
-      "icon-class": "ai-corp"
-    },
-    "modal-navbar-override": {
-      "button-list": [
-        {
-          "button-class": "a-modal-back",
-          "aria-label": "Tilbake",
+{
+  "variation-class": "a-iconText-background a-iconText-large",
+  "hasIcon": {
+    "icon-prefix": "ai",
+    "icon-class": "ai-corp"
+  },
+  "modal-navbar-override": {
+    "button-list": [
+      {
+        "button-class": "a-modal-back",
+        "aria-label": "Tilbake",
+        "icon-prefix": "ai",
+        "icon-class": "ai-back",
+        "icon-extra-class": "",
+        "stacked-background": {
           "icon-prefix": "ai",
-          "icon-class": "ai-back",
-          "icon-extra-class": "",
-          "stacked-background": {
-            "icon-prefix": "ai",
-            "icon-class": "ai-plain-circle-big"
-          },
-          "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
-          "enable-popover": false
+          "icon-class": "ai-plain-circle-big"
         },
-        {
-          "button-class": "a-modal-close",
-          "aria-label": "Lukk",
+        "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
+        "enable-popover": false
+      },
+      {
+        "button-class": "a-modal-close",
+        "aria-label": "Lukk",
+        "icon-prefix": "ai",
+        "icon-class": "ai-exit",
+        "icon-extra-class": "a-modal-close-icon",
+        "stacked-background": {
           "icon-prefix": "ai",
-          "icon-class": "ai-exit",
-          "icon-extra-class": "a-modal-close-icon",
-          "stacked-background": {
+          "icon-class": "ai-plain-circle-big"
+        },
+        "onclick": "location.href='link.sider-portal-profil-roller-rettigheter'",
+        "enable-popover": false
+      }
+    ]
+  },
+  "show-others-with-rights-content": {
+    "others-with-rights": {
+      "show-give-rights": false,
+      "show-gi-fjerne-roller": false,
+      "show-missing-email": false,
+      "show-tjenesteoversikt": false,
+      "show-add-rightholder": false,
+      "show-tilgang-tjenester": false,
+      "show-aktivitetslogg": false,
+      "show-local-role": {
+        "local-role-header": "Rediger rolle",
+        "local-role-name-input": {
+          "text-input-id": "text-input-1",
+          "top-label": "Rollenavn:",
+          "text-input-placeholder": "",
+          "input-type": "text",
+          "extra-help": false,
+          "form-label-hasIcon": false,
+          "form-input-hasButton": false,
+          "isHidden": false,
+          "isLarge": false
+        },
+        "local-role-cancel-link": {
+          "button-text": "Slett rolle",
+          "button-class": "a-btn-link a-linkDanger float-left float-md-right",
+          "display-as-link": true,
+          "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
+          "button-type": false
+        },
+        "local-role-service-search": {
+          "text-input-id": "text-input-find-13",
+          "top-label": "Legg til rettigheter:",
+          "text-input-placeholder": "Finn skjema eller tjeneste",
+          "isHidden": false,
+          "input-type": "search",
+          "isRequired": false,
+          "isInput-group": "input-group",
+          "form-label-hasIcon": {
             "icon-prefix": "ai",
-            "icon-class": "ai-plain-circle-big"
+            "icon-class": "ai-document"
           },
-          "onclick": "location.href='link.sider-portal-profil-roller-rettigheter'",
-          "enable-popover": false
-        }
-      ]
-    },
-    "show-others-with-rights-content": {
-      "others-with-rights": {
-        "show-give-rights": false,
-        "show-gi-fjerne-roller": false,
-        "show-missing-email": false,
-        "show-tjenesteoversikt": false,
-        "show-add-rightholder": false,
-        "show-tilgang-tjenester": false,
-        "show-aktivitetslogg": false,
-        "show-local-role": {
-          "local-role-header": "Rediger rolle",
-          "local-role-name-input": {
-            "text-input-id": "text-input-1",
-            "top-label": "Rollenavn:",
-            "text-input-placeholder": "",
-            "input-type": "text",
-            "extra-help": false,
-            "form-label-hasIcon": false,
-            "form-input-hasButton": false,
-            "isHidden": false,
-            "isLarge": false
+          "form-input-hasButton": {
+            "button-icon": {
+              "icon-prefix": "ai",
+              "icon-class": "ai-search"
+            },
+            "button-text": [
+              {
+                "button-text-value": "Søk",
+                "button-text-class": "sr-only"
+              }
+            ]
           },
-          "local-role-cancel-link": {
-            "button-text": "Slett rolle",
-            "button-class": "a-btn-link a-linkDanger float-left float-md-right",
+          "form-control-class": "a-js-autocomplete-multiplecolumns",
+          "autocomplete": true
+        },
+        "local-role-search-header": false,
+        "local-role-search-result": false,
+        "local-role-rights-list": {
+          "local-role-rights-title": "",
+          "additional-classes": "",
+          "tabable": true,
+          "rows": [
+            {
+              "additional-classes": "a-defaultCursor a-dotted",
+              "id": "titleRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center a-accessability-size",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": false,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "a-fontBold",
+                        "text": "Rollen gir følgende rettigheter"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto text-left mr-1",
+                  "onclick": false,
+                  "searchable": false,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "a-fontBold",
+                        "text": "Rediger tilganger"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto a-flex-container-align-items-center justify-content-center a-accessability-size",
+                  "onclick": false,
+                  "searchable": false,
+                  "column-items": [
+                    {
+                      "column-popover": {
+                        "popover-link-text": "Klikk for å se ikon forklaring.",
+                        "popover-link-text-class": "sr-only",
+                        "open-popover-class": "a-helpIconButton a-js-persistPopover a-js-popoverBig a-js-togglePopoverIcons",
+                        "popover-title": "Ikon forklaring:",
+                        "popover-class": "popover",
+                        "popover-content": false,
+                        "popover-content-id": "ikonForklaringContent",
+                        "popover-list-class": "mt-1",
+                        "popover-link-icon": [
+                          {
+                            "icon-prefix": "ai",
+                            "icon-class": "ai-help-popicon",
+                            "icon-extra-class": "",
+                            "stacked-background": {
+                              "stacked-container-class": "a-js-popoverIconInitial ai-sm",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-help-popicon",
+                              "icon-extra-class": ""
+                            }
+                          },
+                          {
+                            "icon-prefix": "ai",
+                            "icon-class": "ai-circle-exit",
+                            "icon-extra-class": "a-accessability-button",
+                            "stacked-background": {
+                              "stacked-container-class": "a-js-popoverIconExpanded ai-sm",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-circle-exit",
+                              "icon-extra-class": ""
+                            }
+                          }
+                        ],
+                        "popover-list-with-icon-content": {
+                          "icon-list-items": [
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Les",
+                              "list-item-name-class": "pl-1",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-read ai-sm ai-nw"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Skriv",
+                              "list-item-name-class": "pl-1",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-write ai-sm ai-nw"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Signer",
+                              "list-item-name-class": "pl-1",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-sign ai-sm ai-nw"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Deaktivert",
+                              "listItemDescription": "Blir ikke delegert",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-sign ai-sm ai-nw",
+                              "icon-extra-class": "a-iconStrikeThrough a-disabledIcon"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Kan ikke delegeres",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-sign ai-sm ai-nw",
+                              "icon-extra-class": "a-iconStrikeThrough a-disabledIcon a-redIcon"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor a-hiddenRow",
+              "id": "hiddenMalRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center",
+              "hidden": true,
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Erklæring om ansvarsrett."
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto text-left",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Les",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-read",
+                          "icon-extra-class": ""
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Skriv",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-write",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Signer",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-sign",
+                          "icon-extra-class": "a-clickable a-iconStrikeThrough a-disabledIcon"
+                        }
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Mangler tilgang",
+                        "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Angre sletting",
+                        "classes": "a-visibleWhenDeleted a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Slett rolle",
+                        "aria-label": "Slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-circle-minus",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Angre slett rolle",
+                        "aria-label": "Angre slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
+                        "tab-index": "-1",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-undo",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor",
+              "id": "firstRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Erklæring om ansvarsrett."
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto text-left",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Les",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-read",
+                          "icon-extra-class": ""
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Skriv",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-write",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Signer",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-sign",
+                          "icon-extra-class": "a-clickable a-iconStrikeThrough a-disabledIcon"
+                        }
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Mangler tilgang",
+                        "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Angre sletting",
+                        "classes": "a-visibleWhenDeleted a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Slett rolle",
+                        "aria-label": "Slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-circle-minus",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Angre slett rolle",
+                        "aria-label": "Angre slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
+                        "tab-index": "-1",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-undo",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor",
+              "id": "secondRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Ferdigattest."
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto  text-left",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Les",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-read",
+                          "icon-extra-class": ""
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Skriv",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-write",
+                          "icon-extra-class": "a-iconStrikeThrough a-redIcon"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Signer",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-sign",
+                          "icon-extra-class": "a-clickable a-iconStrikeThrough a-redIcon"
+                        }
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Mangler tilgang",
+                        "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Angre sletting",
+                        "classes": "a-visibleWhenDeleted a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Slett rolle",
+                        "aria-label": "Slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-circle-minus",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Angre slett rolle",
+                        "aria-label": "Angre slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
+                        "tab-index": "-1",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-undo",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor",
+              "id": "thirdRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Gjennomføringsplan."
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto  text-left",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Les",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-read",
+                          "icon-extra-class": ""
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Skriv",
+                        "button-class": "a-btn-link a-accessability-button a-accessability-size a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-write",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-accessability-size a-hiddenWhenDeleted a-hiddenWhenDisabled a-clickable a-js-toggleRights"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Mangler tilgang",
+                        "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Angre sletting",
+                        "classes": "a-visibleWhenDeleted a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Slett rolle",
+                        "aria-label": "Slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-circle-minus",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Angre slett rolle",
+                        "aria-label": "Angre slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
+                        "tab-index": "-1",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-undo",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "additional-classes": "a-dotted a-selectable a-disabled a-danger",
+              "id": "fourthRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Distribusjonstjeneste for erklæring av ansvarsrett."
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto text-left a-accessability-height",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Les",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "tab-index": "-1",
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-read",
+                          "icon-extra-class": ""
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Skriv",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "tab-index": "-1",
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-write",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Signer",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "tab-index": "-1",
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-sign",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Mangler tilgang",
+                        "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Angre sletting",
+                        "classes": "a-visibleWhenDeleted a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock a-accessability-height"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Slett rolle",
+                        "aria-label": "Slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
+                        "link-url": false,
+                        "tab-index": "-1",
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-circle-minus",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Angre slett rolle",
+                        "aria-label": "Angre slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted a-displayInlineBlock",
+                        "tab-index": "-1",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-undo",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "additional-classes": "a-dotted a-selectable a-defaultCursor",
+              "id": "fifthRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Melding fra Fellestjenester Bygg."
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto  text-left",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Les",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-read",
+                          "icon-extra-class": ""
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Skriv",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-write",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Signer",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-sign",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Mangler tilgang",
+                        "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Angre sletting",
+                        "classes": "a-visibleWhenDeleted a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Slett rolle",
+                        "aria-label": "Slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-circle-minus",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Angre slett rolle",
+                        "aria-label": "Angre slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted a-displayInlineBlock",
+                        "tab-index": "-1",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-undo",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "local-role-buttons": {
+          "local-role-cancel-btn": {
+            "button-text": "Avbryt",
+            "button-class": "a-btn-link",
             "display-as-link": true,
             "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
             "button-type": false
           },
-          "local-role-service-search": {
-            "text-input-id": "text-input-find-13",
-            "top-label": "Legg til rettigheter:",
-            "text-input-placeholder": "Finn skjema eller tjeneste",
-            "isHidden": false,
-            "input-type": "search",
-            "isRequired": false,
-            "isInput-group": "input-group",
-            "form-label-hasIcon": {
-              "icon-prefix": "ai",
-              "icon-class": "ai-document"
-            },
-            "form-input-hasButton": {
-              "button-icon": {
-                "icon-prefix": "ai",
-                "icon-class": "ai-search"
-              },
-              "button-text": [
-                {
-                  "button-text-value": "Søk",
-                  "button-text-class": "sr-only"
-                }
-              ]
-            },
-            "form-control-class": "a-js-autocomplete-multiplecolumns",
-            "autocomplete": true
-          },
-          "local-role-search-header": false,
-          "local-role-search-result": false,
-          "local-role-rights-list": {
-            "local-role-rights-title": "",
-            "additional-classes": "",
-            "tabable": true,
-            "rows": [
-              {
-                "additional-classes": "a-defaultCursor a-dotted",
-                "id": "titleRow",
-                "onclick": false,
-                "row-extra-class": "a-flex-container-align-items-center a-accessability-size",
-                "columns": [
-                  {
-                    "additional-classes": "col-12 col-sm",
-                    "onclick": false,
-                    "searchable": false,
-                    "column-items": [
-                      {
-                        "column-text": {
-                          "classes": "a-fontBold",
-                          "text": "Rollen gir følgende rettigheter"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto text-left mr-1",
-                    "onclick": false,
-                    "searchable": false,
-                    "column-items": [
-                      {
-                        "column-text": {
-                          "classes": "a-fontBold",
-                          "text": "Rediger tilganger"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto a-flex-container-align-items-center justify-content-center a-accessability-size",
-                    "onclick": false,
-                    "searchable": false,
-                    "column-items": [
-                      {
-                        "column-popover": {
-                          "popover-link-text": "Klikk for å se ikon forklaring.",
-                          "popover-link-text-class": "sr-only",
-                          "open-popover-class": "a-helpIconButton a-js-persistPopover a-js-popoverBig a-js-togglePopoverIcons",
-                          "popover-title": "Ikon forklaring:",
-                          "popover-class": "popover",
-                          "popover-content": false,
-                          "popover-content-id": "ikonForklaringContent",
-                          "popover-list-class": "mt-1",
-                          "popover-link-icon": [
-                            {
-                              "icon-prefix": "ai",
-                              "icon-class": "ai-help-popicon",
-                              "icon-extra-class": "",
-                              "stacked-background": {
-                                "stacked-container-class": "a-js-popoverIconInitial ai-sm",
-                                "icon-prefix": "ai",
-                                "icon-class": "ai-help-popicon",
-                                "icon-extra-class": ""
-                              }
-                            },
-                            {
-                              "icon-prefix": "ai",
-                              "icon-class": "ai-circle-exit",
-                              "icon-extra-class": "a-accessability-button",
-                              "stacked-background": {
-                                "stacked-container-class": "a-js-popoverIconExpanded ai-sm",
-                                "icon-prefix": "ai",
-                                "icon-class": "ai-circle-exit",
-                                "icon-extra-class": ""
-                              }
-                            }
-                          ],
-                          "popover-list-with-icon-content": {
-                            "icon-list-items": [
-                              {
-                                "disable-link": true,
-                                "list-item-name": "Les",
-                                "list-item-name-class": "pl-1",
-                                "listItemDescription": "",
-                                "icon-prefix": "ai",
-                                "icon-class": "ai-read ai-sm ai-nw"
-                              },
-                              {
-                                "disable-link": true,
-                                "list-item-name": "Skriv",
-                                "list-item-name-class": "pl-1",
-                                "listItemDescription": "",
-                                "icon-prefix": "ai",
-                                "icon-class": "ai-write ai-sm ai-nw"
-                              },
-                              {
-                                "disable-link": true,
-                                "list-item-name": "Signer",
-                                "list-item-name-class": "pl-1",
-                                "listItemDescription": "",
-                                "icon-prefix": "ai",
-                                "icon-class": "ai-sign ai-sm ai-nw"
-                              },
-                              {
-                                "disable-link": true,
-                                "list-item-name": "Deaktivert",
-                                "listItemDescription": "Blir ikke delegert",
-                                "icon-prefix": "ai",
-                                "icon-class": "ai-sign ai-sm ai-nw",
-                                "icon-extra-class": "a-iconStrikeThrough a-disabledIcon"
-                              },
-                              {
-                                "disable-link": true,
-                                "list-item-name": "Kan ikke delegeres",
-                                "listItemDescription": "",
-                                "icon-prefix": "ai",
-                                "icon-class": "ai-sign ai-sm ai-nw",
-                                "icon-extra-class": "a-iconStrikeThrough a-disabledIcon a-redIcon"
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor",
-                "id": "firstRow",
-                "onclick": false,
-                "row-extra-class": "a-flex-container-align-items-center",
-                "columns": [
-                  {
-                    "additional-classes": "col-12 col-sm",
-                    "onclick": false,
-                    "searchable": true,
-                    "column-items": [
-                      {
-                        "column-text": {
-                          "classes": "",
-                          "text": "Erklæring om ansvarsrett."
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto text-left",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Les",
-                          "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-read",
-                            "icon-extra-class": ""
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Skriv",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-write",
-                            "icon-extra-class": "a-clickable"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Signer",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-sign",
-                            "icon-extra-class": "a-clickable a-iconStrikeThrough a-disabledIcon"
-                          }
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Mangler tilgang",
-                          "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Angre sletting",
-                          "classes": "a-visibleWhenDeleted a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Slett rolle",
-                          "aria-label": "Slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-circle-minus",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Angre slett rolle",
-                          "aria-label": "Angre slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
-                          "tab-index": "-1",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-undo",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-icon": {
-                          "icon-prefix": "ai",
-                          "icon-class": "ai-fw",
-                          "tab-index": "-1",
-                          "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor",
-                "id": "secondRow",
-                "onclick": false,
-                "row-extra-class": "a-flex-container-align-items-center",
-                "columns": [
-                  {
-                    "additional-classes": "col-12 col-sm",
-                    "onclick": false,
-                    "searchable": true,
-                    "column-items": [
-                      {
-                        "column-text": {
-                          "classes": "",
-                          "text": "Ferdigattest."
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto  text-left",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Les",
-                          "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-read",
-                            "icon-extra-class": ""
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Skriv",
-                          "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-write",
-                            "icon-extra-class": "a-iconStrikeThrough a-redIcon"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Signer",
-                          "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-sign",
-                            "icon-extra-class": "a-clickable a-iconStrikeThrough a-redIcon"
-                          }
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Mangler tilgang",
-                          "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Angre sletting",
-                          "classes": "a-visibleWhenDeleted a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Slett rolle",
-                          "aria-label": "Slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-circle-minus",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Angre slett rolle",
-                          "aria-label": "Angre slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
-                          "tab-index": "-1",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-undo",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-icon": {
-                          "icon-prefix": "ai",
-                          "icon-class": "ai-fw",
-                          "tab-index": "-1",
-                          "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor",
-                "id": "thirdRow",
-                "onclick": false,
-                "row-extra-class": "a-flex-container-align-items-center",
-                "columns": [
-                  {
-                    "additional-classes": "col-12 col-sm",
-                    "onclick": false,
-                    "searchable": true,
-                    "column-items": [
-                      {
-                        "column-text": {
-                          "classes": "",
-                          "text": "Gjennomføringsplan."
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto  text-left",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Les",
-                          "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-read",
-                            "icon-extra-class": ""
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Skriv",
-                          "button-class": "a-btn-link a-accessability-button a-accessability-size a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-write",
-                            "icon-extra-class": "a-clickable"
-                          }
-                        }
-                      },
-                      {
-                        "column-icon": {
-                          "icon-prefix": "ai",
-                          "icon-class": "ai-fw",
-                          "tab-index": "-1",
-                          "icon-extra-class": "a-accessability-size a-hiddenWhenDeleted a-hiddenWhenDisabled a-clickable a-js-toggleRights"
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Mangler tilgang",
-                          "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Angre sletting",
-                          "classes": "a-visibleWhenDeleted a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Slett rolle",
-                          "aria-label": "Slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-circle-minus",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Angre slett rolle",
-                          "aria-label": "Angre slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
-                          "tab-index": "-1",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-undo",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-icon": {
-                          "icon-prefix": "ai",
-                          "icon-class": "ai-fw",
-                          "tab-index": "-1",
-                          "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "additional-classes": "a-dotted a-selectable a-disabled a-danger",
-                "id": "fourthRow",
-                "onclick": false,
-                "row-extra-class": "a-flex-container-align-items-center",
-                "columns": [
-                  {
-                    "additional-classes": "col-12 col-sm",
-                    "onclick": false,
-                    "searchable": true,
-                    "column-items": [
-                      {
-                        "column-text": {
-                          "classes": "",
-                          "text": "Distribusjonstjeneste for erklæring av ansvarsrett."
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto text-left a-accessability-height",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Les",
-                          "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "tab-index": "-1",
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-read",
-                            "icon-extra-class": ""
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Skriv",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "tab-index": "-1",
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-write",
-                            "icon-extra-class": "a-clickable"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Signer",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "tab-index": "-1",
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-sign",
-                            "icon-extra-class": "a-clickable"
-                          }
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Mangler tilgang",
-                          "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Angre sletting",
-                          "classes": "a-visibleWhenDeleted a-displayInlineBlock"
-                        }
-                      },
-                      {
-                        "column-icon": {
-                          "icon-prefix": "ai",
-                          "icon-class": "ai-fw",
-                          "tab-index": "-1",
-                          "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock a-accessability-height"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Slett rolle",
-                          "aria-label": "Slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
-                          "link-url": false,
-                          "tab-index": "-1",
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-circle-minus",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Angre slett rolle",
-                          "aria-label": "Angre slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted a-displayInlineBlock",
-                          "tab-index": "-1",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-undo",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-icon": {
-                          "icon-prefix": "ai",
-                          "icon-class": "ai-fw",
-                          "tab-index": "-1",
-                          "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "additional-classes": "a-dotted a-selectable a-defaultCursor",
-                "id": "fifthRow",
-                "onclick": false,
-                "row-extra-class": "a-flex-container-align-items-center",
-                "columns": [
-                  {
-                    "additional-classes": "col-12 col-sm",
-                    "onclick": false,
-                    "searchable": true,
-                    "column-items": [
-                      {
-                        "column-text": {
-                          "classes": "",
-                          "text": "Melding fra Fellestjenester Bygg."
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto  text-left",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Les",
-                          "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-read",
-                            "icon-extra-class": ""
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Skriv",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-write",
-                            "icon-extra-class": "a-clickable"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Signer",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-sign",
-                            "icon-extra-class": "a-clickable"
-                          }
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Mangler tilgang",
-                          "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
-                        }
-                      },
-                      {
-                        "column-text": {
-                          "text": "Angre sletting",
-                          "classes": "a-visibleWhenDeleted a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "additional-classes": "col-auto",
-                    "onclick": false,
-                    "column-items": [
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Slett rolle",
-                          "aria-label": "Slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-circle-minus",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-button": {
-                          "button-text": false,
-                          "title": "Angre slett rolle",
-                          "aria-label": "Angre slett rolle",
-                          "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted a-displayInlineBlock",
-                          "tab-index": "-1",
-                          "link-url": false,
-                          "button-shadow-label": false,
-                          "button-icon": {
-                            "icon-prefix": "ai",
-                            "icon-class": "ai-undo",
-                            "icon-extra-class": "a-danger"
-                          }
-                        }
-                      },
-                      {
-                        "column-icon": {
-                          "icon-prefix": "ai",
-                          "icon-class": "ai-fw",
-                          "tab-index": "-1",
-                          "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          "local-role-buttons": {
-            "local-role-cancel-btn": {
-              "button-text": "Avbryt",
-              "button-class": "a-btn-link",
-              "display-as-link": true,
-              "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
-              "button-type": false
-            },
-            "local-role-save-btn": {
-              "button-text": "Lagre",
-              "id": "lagre-knapp",
-              "button-class": "a-btn a-btn-success mr-2",
-              "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
-              "button-icon": false,
-              "button-type": false
-            }
+          "local-role-save-btn": {
+            "button-text": "Lagre",
+            "id": "lagre-knapp",
+            "button-class": "a-btn a-btn-success mr-2",
+            "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
+            "button-icon": false,
+            "button-type": false
           }
         }
       }
     }
   }
+}

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~egendefinert-rolle.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~egendefinert-rolle.json
@@ -1,107 +1,361 @@
-  {
-    "variation-class": "a-iconText-background a-iconText-large",
-    "hasIcon": {
-      "icon-prefix": "ai",
-      "icon-class": "ai-corp"
-    },
-    "modal-navbar-override": {
-      "button-list": [
-        {
-          "button-class": "a-modal-back",
-          "aria-label": "Tilbake",
+{
+  "variation-class": "a-iconText-background a-iconText-large",
+  "hasIcon": {
+    "icon-prefix": "ai",
+    "icon-class": "ai-corp"
+  },
+  "modal-navbar-override": {
+    "button-list": [
+      {
+        "button-class": "a-modal-back",
+        "aria-label": "Tilbake",
+        "icon-prefix": "ai",
+        "icon-class": "ai-back",
+        "icon-extra-class": "",
+        "stacked-background": {
           "icon-prefix": "ai",
-          "icon-class": "ai-back",
-          "icon-extra-class": "",
-          "stacked-background": {
-            "icon-prefix": "ai",
-            "icon-class": "ai-plain-circle-big"
-          },
-          "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
-          "enable-popover": false
+          "icon-class": "ai-plain-circle-big"
         },
-        {
-          "button-class": "a-modal-close",
-          "aria-label": "Lukk",
+        "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
+        "enable-popover": false
+      },
+      {
+        "button-class": "a-modal-close",
+        "aria-label": "Lukk",
+        "icon-prefix": "ai",
+        "icon-class": "ai-exit",
+        "icon-extra-class": "a-modal-close-icon",
+        "stacked-background": {
           "icon-prefix": "ai",
-          "icon-class": "ai-exit",
-          "icon-extra-class": "a-modal-close-icon",
-          "stacked-background": {
+          "icon-class": "ai-plain-circle-big"
+        },
+        "onclick": "location.href='link.sider-portal-profil-roller-rettigheter'",
+        "enable-popover": false
+      }
+    ]
+  },
+  "show-others-with-rights-content": {
+    "others-with-rights": {
+      "show-give-rights": false,
+      "show-gi-fjerne-roller": false,
+      "show-missing-email": false,
+      "show-tjenesteoversikt": false,
+      "show-add-rightholder": false,
+      "show-tilgang-tjenester": false,
+      "show-aktivitetslogg": false,
+      "show-local-role": {
+        "local-role-header": "Opprett rolle",
+        "local-role-name-input": {
+          "text-input-id": "text-input-1",
+          "top-label": "Rollenavn:",
+          "text-input-placeholder": "",
+          "input-type": "text",
+          "extra-help": false,
+          "form-label-hasIcon": false,
+          "form-input-hasButton": false,
+          "isHidden": false,
+          "isLarge": false
+        },
+        "local-role-service-search": {
+          "text-input-id": "text-input-find-13",
+          "top-label": "Legg til rettigheter:",
+          "text-input-placeholder": "Finn skjema eller tjeneste",
+          "input-type": "search",
+          "isRequired": false,
+          "isInput-group": "input-group",
+          "form-label-hasIcon": {
             "icon-prefix": "ai",
-            "icon-class": "ai-plain-circle-big"
+            "icon-class": "ai-document"
           },
-          "onclick": "location.href='link.sider-portal-profil-roller-rettigheter'",
-          "enable-popover": false
-        }
-      ]
-    },
-    "show-others-with-rights-content": {
-      "others-with-rights": {
-        "show-give-rights": false,
-        "show-gi-fjerne-roller": false,
-        "show-missing-email": false,
-        "show-tjenesteoversikt": false,
-        "show-add-rightholder": false,
-        "show-tilgang-tjenester": false,
-        "show-aktivitetslogg": false,
-        "show-local-role": {
-          "local-role-header": "Opprett rolle",
-          "local-role-name-input": {
-            "text-input-id": "text-input-1",
-            "top-label": "Rollenavn:",
-            "text-input-placeholder": "",
-            "input-type": "text",
-            "extra-help": false,
-            "form-label-hasIcon": false,
-            "form-input-hasButton": false,
-            "isHidden": false,
-            "isLarge": false
-          },
-          "local-role-service-search": {
-            "text-input-id": "text-input-find-13",
-            "top-label": "Legg til rettigheter:",
-            "text-input-placeholder": "Finn skjema eller tjeneste",
-            "input-type": "search",
-            "isRequired": false,
-            "isInput-group": "input-group",
-            "form-label-hasIcon": {
+          "form-input-hasButton": {
+            "button-icon": {
               "icon-prefix": "ai",
-              "icon-class": "ai-document"
+              "icon-class": "ai-search"
             },
-            "form-input-hasButton": {
-              "button-icon": {
-                "icon-prefix": "ai",
-                "icon-class": "ai-search"
-              },
-              "button-text": [
+            "button-text": [
+              {
+                "button-text-value": "Søk",
+                "button-text-class": "sr-only"
+              }
+            ]
+          },
+          "form-control-class": "a-js-autocomplete-multiplecolumns",
+          "autocomplete": true
+        },
+        "local-role-search-header": false,
+        "local-role-search-result": false,
+        "local-role-rights-list": {
+          "local-role-rights-title": "",
+          "additional-classes": "",
+          "tabable": true,
+          "rows": [
+            {
+              "additional-classes": "a-defaultCursor a-dotted",
+              "id": "titleRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center a-accessability-size",
+              "columns": [
                 {
-                  "button-text-value": "Søk",
-                  "button-text-class": "sr-only"
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": false,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "a-fontBold",
+                        "text": "Rollen gir følgende rettigheter"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto text-left mr-1",
+                  "onclick": false,
+                  "searchable": false,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "a-fontBold",
+                        "text": "Rediger tilganger"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto a-flex-container-align-items-center justify-content-center a-accessability-size",
+                  "onclick": false,
+                  "searchable": false,
+                  "column-items": [
+                    {
+                      "column-popover": {
+                        "popover-link-text": "Klikk for å se ikon forklaring.",
+                        "popover-link-text-class": "sr-only",
+                        "open-popover-class": "a-helpIconButton a-js-persistPopover a-js-popoverBig a-js-togglePopoverIcons",
+                        "popover-title": "Ikon forklaring:",
+                        "popover-class": "popover",
+                        "popover-content": false,
+                        "popover-content-id": "ikonForklaringContent",
+                        "popover-list-class": "mt-1",
+                        "popover-link-icon": [
+                          {
+                            "icon-prefix": "ai",
+                            "icon-class": "ai-help-popicon",
+                            "icon-extra-class": "",
+                            "stacked-background": {
+                              "stacked-container-class": "a-js-popoverIconInitial ai-sm",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-help-popicon",
+                              "icon-extra-class": ""
+                            }
+                          },
+                          {
+                            "icon-prefix": "ai",
+                            "icon-class": "ai-circle-exit",
+                            "icon-extra-class": "a-accessability-button",
+                            "stacked-background": {
+                              "stacked-container-class": "a-js-popoverIconExpanded ai-sm",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-circle-exit",
+                              "icon-extra-class": ""
+                            }
+                          }
+                        ],
+                        "popover-list-with-icon-content": {
+                          "icon-list-items": [
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Les",
+                              "list-item-name-class": "pl-1",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-read ai-sm ai-nw"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Skriv",
+                              "list-item-name-class": "pl-1",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-write ai-sm ai-nw"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Signer",
+                              "list-item-name-class": "pl-1",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-sign ai-sm ai-nw"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Deaktivert",
+                              "listItemDescription": "Blir ikke delegert",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-sign ai-sm ai-nw",
+                              "icon-extra-class": "a-iconStrikeThrough a-disabledIcon"
+                            },
+                            {
+                              "disable-link": true,
+                              "list-item-name": "Kan ikke delegeres",
+                              "listItemDescription": "",
+                              "icon-prefix": "ai",
+                              "icon-class": "ai-sign ai-sm ai-nw",
+                              "icon-extra-class": "a-iconStrikeThrough a-disabledIcon a-redIcon"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               ]
             },
-            "form-control-class": "a-js-autocomplete",
-            "autocomplete": true
-          },
-          "local-role-search-header": false,
-          "local-role-search-result": false,
-          "local-role-buttons": {
-            "local-role-cancel-btn": {
-              "button-text": "Avbryt",
-              "button-class": "a-btn-link",
-              "display-as-link": true,
-              "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
-              "button-type": false
-            },
-            "local-role-save-btn": {
-              "button-text": "Lagre",
-              "button-class": "a-btn a-btn-success mr-2",
-              "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
-              "button-icon": false,
-              "button-type": false
+            {
+              "additional-classes": "a-dotted a-selectable a-selected a-success a-defaultCursor a-hiddenRow",
+              "id": "hiddenMalRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Erklæring om ansvarsrett."
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto text-left",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Les",
+                        "button-class": "a-btn-link a-accessability-button a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-read",
+                          "icon-extra-class": ""
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Skriv",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-write",
+                          "icon-extra-class": "a-clickable"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Signer",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRights a-hiddenWhenDeleted a-hiddenWhenDisabled",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-sign",
+                          "icon-extra-class": "a-clickable a-iconStrikeThrough a-disabledIcon"
+                        }
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Mangler tilgang",
+                        "classes": "a-danger a-visibleWhenDisabled a-displayInlineBlock"
+                      }
+                    },
+                    {
+                      "column-text": {
+                        "text": "Angre sletting",
+                        "classes": "a-visibleWhenDeleted a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "additional-classes": "col-auto",
+                  "onclick": false,
+                  "column-items": [
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Slett rolle",
+                        "aria-label": "Slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-hiddenWhenDeleted a-hiddenWhenDisabled a-displayInlineBlock",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-circle-minus",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-button": {
+                        "button-text": false,
+                        "title": "Angre slett rolle",
+                        "aria-label": "Angre slett rolle",
+                        "button-class": "a-btn-link a-accessability-button a-js-toggleRightsDelete a-visibleWhenDeleted  a-displayInlineBlock",
+                        "tab-index": "-1",
+                        "link-url": false,
+                        "button-shadow-label": false,
+                        "button-icon": {
+                          "icon-prefix": "ai",
+                          "icon-class": "ai-undo",
+                          "icon-extra-class": "a-danger"
+                        }
+                      }
+                    },
+                    {
+                      "column-icon": {
+                        "icon-prefix": "ai",
+                        "icon-class": "ai-fw",
+                        "tab-index": "-1",
+                        "icon-extra-class": "a-visibleWhenDisabled  a-displayInlineBlock"
+                      }
+                    }
+                  ]
+                }
+              ]
             }
+          ]
+        },
+        "local-role-buttons": {
+          "local-role-cancel-btn": {
+            "button-text": "Avbryt",
+            "button-class": "a-btn-link",
+            "display-as-link": true,
+            "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
+            "button-type": false
           },
-          "local-role-cancel-link": false
-        }
+          "local-role-save-btn": {
+            "button-text": "Lagre",
+            "button-class": "a-btn a-btn-success mr-2",
+            "onclick": "location.href='link.sider-portal-andre-med-rettigheter-roller-gi'",
+            "button-icon": false,
+            "button-type": false
+          }
+        },
+        "local-role-cancel-link": false
       }
     }
   }
+}

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~egendefinert-rolle.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~egendefinert-rolle.json
@@ -335,6 +335,27 @@
                   ]
                 }
               ]
+            },
+            {
+              "additional-classes": "a-dotted a-defaultCursor",
+              "id": "emptyRow",
+              "onclick": false,
+              "row-extra-class": "a-flex-container-align-items-center a-accessability-size",
+              "columns": [
+                {
+                  "additional-classes": "col-12 col-sm text-center",
+                  "onclick": false,
+                  "searchable": true,
+                  "column-items": [
+                    {
+                      "column-text": {
+                        "classes": "",
+                        "text": "Rollen har ingen rettigheter. Benytt søket for å legge til tjenesterettigheter."
+                      }
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
@@ -50,7 +50,7 @@
       },
       "service-search": {
         "text-input-id": "text-input-find-13",
-        "top-label": "Legg til rettigheter:",
+        "top-label": false,
         "text-input-placeholder": "Finn skjema eller tjeneste",
         "isHidden": false,
         "input-type": "search",

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
@@ -48,26 +48,35 @@
         "button-class": "a-btn-link a-linkDanger float-left float-md-right",
         "display-as-link": true
       },
-      "search-title": "Gi nye rettigheter:",
-      "text-input-placeholder": "Finn skjema eller tjeneste",
-      "top-label": "Finn skjema eller tjeneste",
-      "isHidden": true,
-      "form-label-hasIcon": {
-        "icon-prefix": "ai",
-        "icon-class": "ai-document"
-      },
-      "form-input-hasButton": {
-        "button-icon": {
+      "service-search": {
+        "text-input-id": "text-input-find-13",
+        "top-label": "Legg til rettigheter:",
+        "text-input-placeholder": "Finn skjema eller tjeneste",
+        "isHidden": false,
+        "input-type": "search",
+        "isRequired": false,
+        "isInput-group": "input-group",
+        "form-label-hasIcon": {
           "icon-prefix": "ai",
-          "icon-class": "ai-search"
+          "icon-class": "ai-document"
         },
-        "button-text": [
-          {
-            "button-text-value": "Søk",
-            "button-text-class": "sr-only"
-          }
-        ]
+        "form-input-hasButton": {
+          "button-icon": {
+            "icon-prefix": "ai",
+            "icon-class": "ai-search"
+          },
+          "button-text": [
+            {
+              "button-text-value": "Søk",
+              "button-text-class": "sr-only"
+            }
+          ]
+        },
+        "form-control-class": "a-js-autocomplete",
+        "autocomplete": true
       },
+      "search-header": false,
+      "search-result": false,
       "expandable-list": [
         {
           "collapse-header-title": "Har disse <span class='badge badge-primary a-label badge-pill'>2</span> rollene:",

--- a/source/css/scss-common/base/_global-classes.scss
+++ b/source/css/scss-common/base/_global-classes.scss
@@ -430,6 +430,10 @@ hr {
   }
 }
 
+.a-hiddenRow {
+  display: none;
+}
+
 .a-iconStrikeThrough {
   padding-left: 3px;
 

--- a/source/js/prototyping/init.js
+++ b/source/js/prototyping/init.js
@@ -39,6 +39,7 @@
   questionnaireInteraction,
   searchFilterView,
   searchWithAutocomplete,
+  searchWithAutocompleteVarsel,
   searchWithMultipleSelectInAutoComplete,
   selectAll,
   sessionExpiredDialog,
@@ -105,6 +106,7 @@ window.devInit = function() {
   questionnaireInteraction();
   searchFilterView();
   searchWithAutocomplete();
+  searchWithAutocompleteVarsel();
   searchWithMultipleSelectInAutoComplete();
   selectAll();
   sessionExpiredDialog();

--- a/source/js/prototyping/modules/searchWithAutocomplete.js
+++ b/source/js/prototyping/modules/searchWithAutocomplete.js
@@ -1,11 +1,11 @@
 // Hard-coded data, should be replaced with JSON
 var availableTags = [
-  { label: '1. ACC Security level 2 MAG' },
-  { label: '2. Corres test 250116' },
-  { label: '3. PSA Skatteoppgjør personlig' },
-  { label: '4. RF-1400 Melding om flytting innenlands' },
-  { label: '5. Aksjeoppgaven 2014' },
-  { label: '6. Et veldig langt punkt i lista som bør gå over alle bredder og grenser, men samtidig oppføre seg riktig i layout. Se så lang tekst dette her er.' }
+  { label: 'ACC Security level 2 MAG, Accenture Test', service: 'ACC Security level 2 MAG', serviceOwner: 'Accenture Test' },
+  { label: 'Corres test 250116, Accenture Test', service: 'Corres test 250116', serviceOwner: 'Accenture Test' },
+  { label: 'PSA Skatteoppgjør personlig, Skatteetaten', service: 'PSA Skatteoppgjør personlig', serviceOwner: 'Skatteetaten' },
+  { label: 'RF-1400 Melding om flytting innenlands,Skatteetaten', service: 'RF-1400 Melding om flytting innenlands', serviceOwner: 'Skatteetaten' },
+  { label: 'Aksjeoppgaven 2014, Skatteetaten', service: 'Aksjeoppgaven 2014', serviceOwner: 'Skatteetaten' },
+  { label: 'Et veldig langt punkt i lista som bør gå over alle bredder og grenser, men samtidig oppføre seg riktig i layout. Se så lang tekst dette her er., accenture', service: 'Et veldig langt punkt i lista som bør gå over alle bredder og grenser, men samtidig oppføre seg riktig i layout. Se så lang tekst dette her er.', serviceOwner: 'accenture' }
 ];
 
 // Hard-coded texts, should be replaced with custom strings
@@ -26,10 +26,25 @@ var searchWithAutocomplete = function() {
       var iLength = items.length;
 
       $.each(items, function(index, item) {
+        // build  item in the list
+        var innerHtmlForItem = '<div class="row">' +
+          '<div class="col-sm-7 col-md-5 col-lg-6 pl-md-2 pl-lg-2 pr-2" data-searchable="true">' +
+            '<span class="a-js-sortValue a-list-longtext" title="ACC Security level 2 MAG">' + item.service + '</span>' +
+          '</div>' +
+          '<div class="d-none d-md-block col-md-3 col-lg-4 pl-md-2 pl-lg-1 pr-2" data-searchable="true">' +
+            '<span class="a-js-sortValue a-list-longtext" title="Testetat for Accenture">' + item.serviceOwner + '</span>' +
+          '</div>' +
+        '</div>';
+
         var li = that._renderItemData(ul, item);
-        li.attr('role', 'menu');
-        li.addClass('a-dotted');
+        li.data('item.autocomplete', item);
+        li.children().first().remove();
+        li.append(innerHtmlForItem);
         li.children().first().attr('role', 'button');
+        li.attr('role', 'menu');
+        li.addClass('a-dotted a-selectable');
+        li.attr('id', 'menu-item-' + index);
+        li.attr('onclick', "location.href='/patterns/04-sider-portal-92-andre-med-rettigheter-00-andre-med-rettigheter-tildel-enkeltrettigheter/04-sider-portal-92-andre-med-rettigheter-00-andre-med-rettigheter-tildel-enkeltrettigheter.html'")
       });
 
       if (iLength === availableTags.length) {
@@ -84,8 +99,6 @@ var searchWithAutocomplete = function() {
   }).bind('click', function(e) { // TODO should also open on tab focus? issue 3766
     if ($(this).catcomplete('widget').is(':visible')) {
       $(this).catcomplete('close');
-    } else {
-      $(this).catcomplete('search', $(this).val());
     }
   });
 };

--- a/source/js/prototyping/modules/searchWithAutocomplete.js
+++ b/source/js/prototyping/modules/searchWithAutocomplete.js
@@ -44,7 +44,7 @@ var searchWithAutocomplete = function() {
         li.attr('role', 'menu');
         li.addClass('a-dotted a-selectable');
         li.attr('id', 'menu-item-' + index);
-        li.attr('onclick', "location.href='/patterns/04-sider-portal-92-andre-med-rettigheter-00-andre-med-rettigheter-tildel-enkeltrettigheter/04-sider-portal-92-andre-med-rettigheter-00-andre-med-rettigheter-tildel-enkeltrettigheter.html'")
+        li.attr('onclick', 'location.href="/patterns/04-sider-portal-92-andre-med-rettigheter-00-andre-med-rettigheter-tildel-enkeltrettigheter/04-sider-portal-92-andre-med-rettigheter-00-andre-med-rettigheter-tildel-enkeltrettigheter.html"');
       });
 
       if (iLength === availableTags.length) {

--- a/source/js/prototyping/modules/searchWithAutocompleteVarselEnkeltTjeneste.js
+++ b/source/js/prototyping/modules/searchWithAutocompleteVarselEnkeltTjeneste.js
@@ -1,5 +1,3 @@
-/* eslint vars-on-top: 1 */
-
 // Hard-coded data, should be replaced with JSON
 var availableTags = [
   { label: 'ACC Security level 2 MAG, Accenture Test', service: 'ACC Security level 2 MAG', serviceOwner: 'Accenture Test' },
@@ -16,7 +14,7 @@ var numberOfResultsLabel = ' treff. Bruk pil opp og pil ned for å navigere i re
 var noResultsLabel = 'Ingen treff';
 var moreThanMaxLabel = 'Listen viser kun de første 100 treff. Vennligst begrens søket ditt';
 
-var searchWithMultipleSelectInAutoComplete = function() {
+var searchWithAutocompleteVarsel = function() {
   $.widget('custom.catcomplete', $.ui.autocomplete, ({
     _create: function() {
       this._super();
@@ -36,10 +34,6 @@ var searchWithMultipleSelectInAutoComplete = function() {
           '<div class="d-none d-md-block col-md-3 col-lg-4 pl-md-2 pl-lg-1 pr-2" data-searchable="true">' +
             '<span class="a-js-sortValue a-list-longtext" title="Testetat for Accenture">' + item.serviceOwner + '</span>' +
           '</div>' +
-          '<div class="text-right col-sm-5 col-md-4 col-lg-2 pl-md-2 pl-lg-1 pr-sm-0 pr-md-2">' +
-              '<span class="a-fontBold a-btn-icon-text a-hiddenWhenSelected ">+Legg til</span>' +
-              '<span class="a-fontBold d-none d-sm-block a-visibleWhenSelected">Lagt til</span>' +
-          '</div>' +
         '</div>';
 
         var li = that._renderItemData(ul, item);
@@ -50,11 +44,6 @@ var searchWithMultipleSelectInAutoComplete = function() {
         li.attr('role', 'menu');
         li.addClass('a-dotted a-selectable');
         li.attr('id', 'menu-item-' + index);
-        /* var li = that._renderItemData(ul, item);
-        console.log(li);
-        li.attr('role', 'menu');
-        li.addClass('a-dotted');
-        li.children().first().attr('role', 'button');*/
       });
 
       if (iLength === availableTags.length) {
@@ -68,46 +57,19 @@ var searchWithMultipleSelectInAutoComplete = function() {
       if (iLength >= 3) {
         ul.append('<li class=\'a-js-autocomplete-header a-dotted a-info\'>' + moreThanMaxLabel + '</li>');
       }
-
-      // Lukkeknapp
-      /*
-      ul.append('<li class="a-js-autocomplete-header ml-2 a-no-border-bottom">' +
-                  '<div class="mt-1 mb-1 d-flex justify-content-center">' +
-                    '<button id="closeAutoCompleteMenu" class="a-btn pl-1 pr-1">Lukk</button>' +
-                  '</div>' +
-                '</li>');
-      */
     },
-    oldClose: $.ui.autocomplete.prototype.close,
-    close: function(event) {
-      var bolClose;
-      if (event) {
-        bolClose = false;
-      } else {
-        bolClose = true;
-        $('button:contains(\'Lagre\')').removeAttr('disabled');
-      }
-
-      // Actuall close
-      if (bolClose) {
-        this.oldClose(event);
-      }
-
-      return false;
-    }
   }));
 
-  $('.a-js-autocomplete-multiplecolumns').catcomplete({
+  $('.a-js-autocomplete-varsel').catcomplete({
     // delay: 200, // set appropriate delay for ajax call
     source: availableTags,
     appendTo: '.a-autocomplete-container',
     minLength: 0,
     classes: {
-      'ui-autocomplete': 'a-list a-multipleSelectInAutoComplete',
+      'ui-autocomplete': 'a-list',
       'ui-menu-item': 'a-dotted'
     },
     open: function(event, ui) {
-      $('button:contains(\'Lagre\')').attr('disabled', 'disabled');
       $('.ui-autocomplete').removeAttr('style'); // remove inline positioning and display of amount results
       $('.ui-autocomplete .ui-menu-item').not(':first-of-type').addClass('a-clickable');
     },
@@ -123,7 +85,6 @@ var searchWithMultipleSelectInAutoComplete = function() {
     },
     response: function(event, ui) {
       var el;
-      // console.log(ui.content.length);
       if (ui.content.length === 0) {
         el = {
           isNoResultsLabel: true,
@@ -150,7 +111,7 @@ var searchWithMultipleSelectInAutoComplete = function() {
 
       // ONLY FOR DESIGNSYSTEM PROTOTYPING
       // eslint-disable-next-line
-      console.log('Prototyping feature needs to be commented out in searchWithMultipleSelectInAutoComplete.js');
+      console.log('Prototyping feature needs to be commented out in searchWithAutocompleteVarselEnkeltTjeneste.js');
       // Add the clicked rights to list, only if if not already in list
       if ($('.a-list-container').find('div:contains(' + ui.item.service + ')').length === 0) {
         // eslint-disable-next-line

--- a/source/js/prototyping/modules/searchWithAutocompleteVarselEnkeltTjeneste.js
+++ b/source/js/prototyping/modules/searchWithAutocompleteVarselEnkeltTjeneste.js
@@ -57,7 +57,7 @@ var searchWithAutocompleteVarsel = function() {
       if (iLength >= 3) {
         ul.append('<li class=\'a-js-autocomplete-header a-dotted a-info\'>' + moreThanMaxLabel + '</li>');
       }
-    },
+    }
   }));
 
   $('.a-js-autocomplete-varsel').catcomplete({

--- a/source/js/prototyping/modules/searchWithMultipleSelectInAutoComplete.js
+++ b/source/js/prototyping/modules/searchWithMultipleSelectInAutoComplete.js
@@ -154,6 +154,7 @@ var searchWithMultipleSelectInAutoComplete = function() {
       // Add the clicked rights to list, only if if not already in list
       if ($('.a-list-container').find('div:contains(' + ui.item.service + ')').length === 0) {
         // eslint-disable-next-line
+        var emptyListItem = $('#emptyRow');
         var firstListItem = $('#hiddenMalRow').clone();
         firstListItem.removeClass('a-hiddenRow');
         firstListItem.attr('id', 'last');
@@ -162,6 +163,7 @@ var searchWithMultipleSelectInAutoComplete = function() {
         });
         firstListItem.first().addClass('a-selected a-success');
         firstListItem.find('button:nth-of-type(3) > i').removeClass('a-iconStrikeThrough a-disabledIcon');
+        emptyListItem.addClass('a-hiddenRow');
         $('.a-list-container > ul').append(firstListItem);
       }
 


### PR DESCRIPTION
- Oppdatert resultat liste for tjenestesøk til å inneholde ServiceOwner under "Andre med rettigheter" og "Varsel for enkelttjenester"

- Oppdatert oppretting av en ny lokal rolle til samme nye design som "Lokal rolle rediger"