### PR TITLE
Modified strike through so that IE is satisfied

### DIFF
--- a/source/css/scss-common/base/_global-classes.scss
+++ b/source/css/scss-common/base/_global-classes.scss
@@ -443,6 +443,11 @@ hr {
     //font-weight: 900;
     color: $black;
     content: '\\';
+
+    @media all and (-ms-high-contrast: none),
+      (-ms-high-contrast: active) {
+        position: static;
+    }
   }
 
   &.a-disabledIcon {
@@ -451,6 +456,14 @@ hr {
 
   &.a-redIcon {
     color: $red;
+  }
+}
+
+.ai-sm {
+  &.a-iconStrikeThrough {
+    &::after {
+      position: relative;
+    }
   }
 }
 


### PR DESCRIPTION
This is to fix the alignment of the content in the strikeThrough-class so that it can be used in Internet Explorer