### PR TITLE
Fix for .modalPage height selector to select only the active/visible modal page

### DIFF
--- a/source/js/production/modules/popover.js
+++ b/source/js/production/modules/popover.js
@@ -199,9 +199,9 @@ var popoverGlobalInit = function() {
     if ($('.popover-big').length > 0) {
       if ($('.modal.show').length > 0) {
         // Add padding to make sure modal is big enough to contain popover
-        modalHeight = $('.modal-dialog').height() + $('.modalPage').height();
+        modalHeight = $('.modal-dialog').height() + $('.modalPage:visible').height();
         padding = ($('.popover').offset().top + $('.modal').scrollTop() + $('.popover').height() + 5) - modalHeight;
-        $('.modalPage').css('padding-bottom', padding + 'px');
+        $('.modalPage:visible').css('padding-bottom', padding + 'px');
         // tranlate is somehow added by Bootstrap later when in modal??
         setTimeout(resetTranslate, 0);
       } else {


### PR DESCRIPTION
TFS bug 32392:
The roledelegation page for a new actor has two .modalPage elements (previous page also exists). 
This causes the selector to get the wrong (negative) height value. 

Fixed by making the selector only select the active modalPage, both for height retrieval and setting the padding value.