### PR TITLE
IM-1999 Removed click.zf.dropdownmenu event trigger

### DIFF
--- a/source/js/production/modules/colnav.min.js
+++ b/source/js/production/modules/colnav.min.js
@@ -2098,7 +2098,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
         };
 
         if (this.options.clickOpen || hasTouch) {
-          this.$menuItems.on('click.zf.dropdownmenu touchstart.zf.dropdownmenu', handleClickFn);
+          this.$menuItems.on('click.zf.dropdownmenu', handleClickFn);
         }
 
         // Handle Leaf element Clicks


### PR DESCRIPTION
This trigger was removed to fix bug IM-1999 affecting the schemaoverview on infoportal in november 2018, but the change was never added to the designguide.

The affected file is a module from the Zurb Foundation framework.