### PR TITLE
Trigger loaded.altinn.modal when a modal loads new content

### DIFF
--- a/source/js/production/modules/altinnModal.js
+++ b/source/js/production/modules/altinnModal.js
@@ -44,6 +44,7 @@ AltinnModal = {
       // }
 
       $(settings.target + ' .a-modal-content-target').append(page);
+      $(settings.target).trigger('loaded.altinn.modal');
       $(settings.target).find('.a-current-page').first().data().enableDirtyPopover = settings.enableDirtyPopover;
 
       // Initialize with backdrop: static to prevent modal from closing when clicking outside,
@@ -121,6 +122,7 @@ AltinnModal = {
     // }
 
     $(settings.target + ' .a-modal-content-target').append(newPage);
+    $(settings.target).trigger('loaded.altinn.modal');
 
     $(settings.target).animate({
       scrollTop: 0
@@ -207,6 +209,7 @@ AltinnModal = {
       // }
 
       $(settings.target + ' .a-modal-content-target').append(newPage);
+      $(settings.target).trigger('loaded.altinn.modal');
 
       $(settings.target).animate({
         scrollTop: 0


### PR DESCRIPTION
These triggers were added to the dist files in infoportal when the eGuide functionality was added in 2018, but never added to the designguide.

The change makes sure events and handlers connected to `loaded.altinn.modal` are executed when a page is loaded as modal content.