### PR TITLE
Fixed design problemmet som  oppstår ved iPad-visning. 

### DIFF
--- a/source/_patterns/00-atomer/01-forms/10-tekst-input.mustache
+++ b/source/_patterns/00-atomer/01-forms/10-tekst-input.mustache
@@ -86,7 +86,7 @@
 
     </div>
     {{# autocomplete }}
-      <div class="a-autocomplete-container d-none d-block {{ autocomplate-additional-classes }}">
+      <div class="a-autocomplete-container d-none d-block {{ autocomplete-additional-classes }}">
       </div>
     {{/ autocomplete}} 
 

--- a/source/_patterns/00-atomer/01-forms/10-tekst-input.mustache
+++ b/source/_patterns/00-atomer/01-forms/10-tekst-input.mustache
@@ -86,9 +86,9 @@
 
     </div>
     {{# autocomplete }}
-      <div class="a-autocomplete-container d-none d-block">
+      <div class="a-autocomplete-container d-none d-block {{ autocomplate-additional-classes }}">
       </div>
-    {{/ autocomplete}}
+    {{/ autocomplete}} 
 
     {{# extra-help }}
       <small id="help" class="form-text a-validatorInfo">

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
@@ -72,8 +72,9 @@
             }
           ]
         },
-        "form-control-class": "a-js-autocomplete",
-        "autocomplete": true
+        "form-control-class": "a-js-autocomplete ",
+        "autocomplete": true,
+        "autocomplate-additional-classes": "a-js-autocomplete-MaxWidth"
       },
       "search-header": false,
       "search-result": false,

--- a/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
+++ b/source/_patterns/04-sider-portal/92-andre-med-rettigheter/00-andre-med-rettigheter~roller-oversikt.json
@@ -74,7 +74,7 @@
         },
         "form-control-class": "a-js-autocomplete ",
         "autocomplete": true,
-        "autocomplate-additional-classes": "a-js-autocomplete-MaxWidth"
+        "autocomplete-additional-classes": "a-js-autocomplete-MaxWidth"
       },
       "search-header": false,
       "search-result": false,

--- a/source/css/scss-common/objects/_lists.scss
+++ b/source/css/scss-common/objects/_lists.scss
@@ -718,10 +718,10 @@ ol {
   background-color: $white;
   border-color: $blue;
   border-width: 2px;
-
-  @include media-breakpoint-up( md ) {
-    width: 200%;
-  }
+  
+    @include media-breakpoint-up( md ){
+        width: 200%;
+    }
 
   .a-list {
     max-height: $spacer * 26;
@@ -767,6 +767,12 @@ ol {
     clip: rect(0 0 0 0);
     border: none;
   }
+}
+
+.a-js-autocomplete-MaxWidth{
+  @include media-breakpoint-down( md ){
+      width: 100%; 
+    }
 }
 
 //long text

--- a/source/css/scss-common/objects/_lists.scss
+++ b/source/css/scss-common/objects/_lists.scss
@@ -718,10 +718,9 @@ ol {
   background-color: $white;
   border-color: $blue;
   border-width: 2px;
-  
-    @include media-breakpoint-up( md ){
-        width: 200%;
-    }
+  @include media-breakpoint-up( md ) {
+    width: 200%;
+  }
 
   .a-list {
     max-height: $spacer * 26;
@@ -769,10 +768,10 @@ ol {
   }
 }
 
-.a-js-autocomplete-MaxWidth{
-  @include media-breakpoint-down( md ){
-      width: 100%; 
-    }
+.a-js-autocomplete-MaxWidth {
+  @include media-breakpoint-down( md ) {
+    width: 100%;
+  }
 }
 
 //long text

--- a/source/css/scss-common/objects/_messaging.scss
+++ b/source/css/scss-common/objects/_messaging.scss
@@ -5,7 +5,7 @@
 .a-message {
   position: relative;
   display: inline-block;
-  min-width: 200px;
+  min-width: 100px;
   padding: $spacer + 2px $spacer * 2 $spacer $spacer * 2;
   margin-top: 12px;
   clear: both;


### PR DESCRIPTION
Det gjenstår en grafisk feil rundt bruken av a-autocomplete-container som brukes i:
- Professional.cshtml (valg av tjenester for varsling under "Din kontaktinformasjon for virksomheten")
- _ServiceSearch.cshtml (valg av tjenester for delegering under delegering av tjenesterettigheter og ved opprettelse av lokal rolle)

Fixen var slik at på den første desinfeilen reduserte min-width fra 200 til 100%
og for den andre feilen lagde vi en classe som hete "autocomplate-additional-classe" og satt den i 10-tekst-input.mustache. Der etter lagde vi ny css regel i _lists.scss som skal fikse liste-visningen i IPad screen. 