### PR TITLE
Fix for Safari bug in search

### DIFF
--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -119,6 +119,7 @@ textarea {
 
   // Button right to input
   .input-group-append {
+    position: relative;
     border: 2px solid $blue;
     border-left: none;
 


### PR DESCRIPTION
The icon right inside search-input is moving left after interacting with input. Fixed with position relative.