### PR TITLE
Bump eslint from 4.18.2 to 4.19.1 and corrected all lint-errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -962,7 +962,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -3401,8 +3401,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3423,14 +3422,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3443,20 +3440,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3571,8 +3565,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3584,7 +3577,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3599,7 +3591,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3613,7 +3604,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3711,8 +3701,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3724,7 +3713,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3809,8 +3797,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3846,7 +3833,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3866,7 +3852,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3895,13 +3880,11 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -4146,7 +4129,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -4780,7 +4763,7 @@
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
@@ -6166,7 +6149,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -6207,7 +6190,7 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
@@ -6927,7 +6910,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -6936,7 +6919,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -6946,8 +6928,7 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6984,7 +6965,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -6993,7 +6974,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -7562,7 +7543,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -7803,7 +7784,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -7812,7 +7793,7 @@
         },
         "lodash": {
           "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=",
           "dev": true
         }
@@ -7908,7 +7889,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -7969,7 +7950,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -8025,7 +8006,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -8034,7 +8015,7 @@
         },
         "lodash": {
           "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=",
           "dev": true
         }
@@ -8727,7 +8708,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         }
@@ -8876,7 +8857,7 @@
         },
         "eslint": {
           "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
           "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
           "dev": true,
           "requires": {
@@ -8949,7 +8930,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -9023,7 +9004,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -10557,7 +10538,7 @@
     },
     "yargs": {
       "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
       "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "clipboard": "1.7.1",
     "csvtojson": "1.1.6",
     "del": "3.0.0",
-    "eslint": "4.18.2",
+    "eslint": "4.19.1",
     "eslint-config-airbnb-base": "11.2.0",
     "eslint-plugin-import": "2.3.0",
     "gulp": "4.0.0",

--- a/source/js/production/modules/altinnQuickhelp.js
+++ b/source/js/production/modules/altinnQuickhelp.js
@@ -108,8 +108,8 @@ AltinnQuickhelp = {
         .attr('data-category')
       );
     $('.a-js-stickyHelpCategoryLink').attr('data-url', $('#a-stickyHelp')
-        .find('.a-stickyHelp-content-target').attr('data-url')
-      );
+      .find('.a-stickyHelp-content-target').attr('data-url')
+    );
     $('body').on('click', '.a-stickyHelp-open', function() {
       if (!$('.a-js-stickyHelpFrame').attr('src')) {
         $('.a-js-stickyHelpFrame')

--- a/source/js/production/modules/colnavCustom.js
+++ b/source/js/production/modules/colnavCustom.js
@@ -253,12 +253,12 @@ var colnavCustom = function() {
           if (open.indexOf(levels[index + 1]) === -1) { // If lower level is not open
             // Prepare lower level and add it to array:
             li.find('.' + levels[index + 1]).removeClass(wasStacked ? '' : 'noTrans')
-                .css('left', '250%').show();
+              .css('left', '250%').show();
             open.push(levels[index + 1]);
           }
           if (index > 0) { // If level is second or lower, calculate left position and width
             calc(el.closest('ul'), 3, index + 1).removeClass('noTrans')
-                .css('width', calc(1.5, null, index)).show();
+              .css('width', calc(1.5, null, index)).show();
           }
           // Calculate left position and width for lower level
           calc(li.find('.' + levels[index + 1]), 3, index + 1).css('width', calc(1.5, null, index))
@@ -295,11 +295,11 @@ var colnavCustom = function() {
       parseInt($('.a-colnav-secondLevel:visible').height(), 10) >
       parseInt($('.a-colnav-firstLevel').height(), 10)) {
       $('.a-colnav-firstLevel')
-          .css('height',
+        .css('height',
           parseInt($('.a-colnav-thirdLevel:visible').height(), 10) >
-              parseInt($('.a-colnav-secondLevel:visible').height(), 10) ?
-              (parseInt($('.a-colnav-thirdLevel:visible').height(), 10) - 2) :
-              (parseInt($('.a-colnav-secondLevel:visible').height(), 10) - 2) +
+            parseInt($('.a-colnav-secondLevel:visible').height(), 10) ?
+            (parseInt($('.a-colnav-thirdLevel:visible').height(), 10) - 2) :
+            (parseInt($('.a-colnav-secondLevel:visible').height(), 10) - 2) +
               'px');
     }
     if (!$('.a-colnav-firstLevel').hasClass('stacked')) {
@@ -353,27 +353,27 @@ var colnavCustom = function() {
         if ($(e.target).blur().parent().prev().length !== 0) {
           stopEvent(e);
           $(e.target).blur().parent().prev()
-              .find(classToQuery)
-              .trigger('focus');
+            .find(classToQuery)
+            .trigger('focus');
         }
       } else if ($(e.target).blur().parent().next().length !== 0) {
         stopEvent(e);
         $(e.target).blur().parent().next()
-            .find(classToQuery)
-            .trigger('focus');
+          .find(classToQuery)
+          .trigger('focus');
       }
     } else if (code === 9 && $(e.target).hasClass('open')) {
       if (shifted) {
         stopEvent(e);
         $(e.target).blur().parent().parent()
-            .parent()
-            .children('a')
-            .trigger('focus');
+          .parent()
+          .children('a')
+          .trigger('focus');
       } else {
         stopEvent(e);
         $(e.target).blur().next().children('li:eq(0)')
-            .children('a')
-            .trigger('focus');
+          .children('a')
+          .trigger('focus');
       }
     }
   }
@@ -470,8 +470,8 @@ var colnavCustom = function() {
   }
 
   function createMenuNodeFragment(item,
-                          level,
-                          index) {
+    level,
+    index) {
     var liClasses = ['',
       'is-dropdown-submenu-parent is-submenu-item is-dropdown-submenu-item opens-right',
       'is-submenu-item is-dropdown-submenu-item'];

--- a/source/js/production/modules/genericSearch.js
+++ b/source/js/production/modules/genericSearch.js
@@ -465,7 +465,7 @@ var genericSearch = function() {
           elements.$noResultsMessage.hide();
           elements.$container.html('');
         }
-      );
+        );
       setInterval(function() {
         var value = $(keys.genericSearchSelector).find('form').find('input[type=search]')
           .val();

--- a/source/js/production/modules/listSort.js
+++ b/source/js/production/modules/listSort.js
@@ -29,7 +29,7 @@ var sortListAlphanumerically = function(src, sortIndex) {
     }
   });
 
-    // handles load more row
+  // handles load more row
   $.each(rows, function(index, row) {
     if ($(row).find('.a-js-sortValue').length === 0) {
       $list.append(row);

--- a/source/js/production/modules/menuToggleEffect.js
+++ b/source/js/production/modules/menuToggleEffect.js
@@ -10,7 +10,7 @@ var action = function(e) {
       if (wasDark) {
         $('header').addClass('a-darkBackground');
         $('.a-globalNav-logo').find('img')
-        .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
+          .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
       }
       $('.a-page').children(':not(header)').removeClass('a-js-hidden');
     }
@@ -22,7 +22,7 @@ var action = function(e) {
       if (wasDark) {
         $('header').addClass('a-darkBackground');
         $('.a-globalNav-logo').find('img')
-        .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
+          .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
       }
       $('.a-page').children(':not(header)').removeClass('a-js-hidden');
     } else {
@@ -32,7 +32,7 @@ var action = function(e) {
       if (wasDark) {
         $('header').removeClass('a-darkBackground');
         $('.a-globalNav-logo').find('img')
-        .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('white', 'blue'));
+          .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('white', 'blue'));
       }
       $('.a-page').children(':not(header)').addClass('a-js-hidden');
     }

--- a/source/js/production/modules/menuToggleEffectAltinnett.js
+++ b/source/js/production/modules/menuToggleEffectAltinnett.js
@@ -9,7 +9,7 @@ var action = function(e) {
       if (wasDark) {
         $('header').addClass('a-darkBackground');
         $('.a-globalNav-logo').find('img')
-        .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
+          .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
       }
       $('.a-page').children(':not(header)').removeClass('a-js-hidden');
     }
@@ -21,7 +21,7 @@ var action = function(e) {
       if (wasDark) {
         $('header').addClass('a-darkBackground');
         $('.a-globalNav-logo').find('img')
-        .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
+          .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('blue', 'white'));
       }
       $('.a-page').children(':not(header)').removeClass('a-js-hidden');
     } else {
@@ -31,7 +31,7 @@ var action = function(e) {
       if (wasDark) {
         $('header').removeClass('a-darkBackground');
         $('.a-globalNav-logo').find('img')
-        .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('white', 'blue'));
+          .attr('src', $('.a-globalNav-logo').find('img').attr('src').replace('white', 'blue'));
       }
       $('.a-page').children(':not(header)').addClass('a-js-hidden');
     }

--- a/source/js/production/modules/personSwitcher.js
+++ b/source/js/production/modules/personSwitcher.js
@@ -46,9 +46,9 @@ $('.a-listWithSubLevels').children().hover(function() {
     $(this).parent().find('button.a-btn-shadow-large.a-bgGreyLight').css('background', '#E2E2E2');
   }
 },
-  function() {
-    if (!$(this).parent().find('button.a-btn-shadow-large').is(':disabled') && ($(this).is('.a-favourite') || $(this).is('.a-btn-shadow-large'))) {
-      $(this).parent().find('button.a-btn-shadow-large').css('background', '#E3F7FF');
-      $(this).parent().find('button.a-btn-shadow-large.a-bgGreyLight').css('background', '#EFEFEF');
-    }
-  });
+function() {
+  if (!$(this).parent().find('button.a-btn-shadow-large').is(':disabled') && ($(this).is('.a-favourite') || $(this).is('.a-btn-shadow-large'))) {
+    $(this).parent().find('button.a-btn-shadow-large').css('background', '#E3F7FF');
+    $(this).parent().find('button.a-btn-shadow-large.a-bgGreyLight').css('background', '#EFEFEF');
+  }
+});

--- a/source/js/production/modules/togglePanel.js
+++ b/source/js/production/modules/togglePanel.js
@@ -7,8 +7,8 @@ $('body').on('show.bs.collapse', '.a-collapsePanel-body', function(e) {
     setTimeout(function() {
       var $collapsePanelHeader = $(that).siblings('.a-js-index-heading').first();
       var $msgIconWrapper = $collapsePanelHeader.find('.a-inboxHeadingContent')
-      .find('.a-msgIconSecondary')
-      .closest('.a-msgIconWrapper');
+        .find('.a-msgIconSecondary')
+        .closest('.a-msgIconWrapper');
 
       $msgIconWrapper.find('.reg')
         .hide()

--- a/source/js/production/modules/toggleRoleRights.js
+++ b/source/js/production/modules/toggleRoleRights.js
@@ -26,10 +26,10 @@ var toggleRoleRightsInit = function() {
     // else if closest li does not have a-deleted
     } else {
       $(this)
-      .parent()
-      .prev()
-      .children()
-      .prop('tabindex', '0');
+        .parent()
+        .prev()
+        .children()
+        .prop('tabindex', '0');
 
       // set tabindex -1 on ai-undo
       $(this).prop('tabindex', '-1');

--- a/source/js/prototyping/modules/nameChecker.js
+++ b/source/js/prototyping/modules/nameChecker.js
@@ -3,7 +3,7 @@ var nameChecker = function() {
   var btnText; var initAction; var toggleBtns;
   if ($('.a-js-validator').length > 0) {
     btnText = $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-    .text();
+      .text();
     initAction = '$(".a-js-validator").find("input[type=text]")' +
     '.attr("disabled", "disabled").parent().addClass("disabled")' +
     '.addClass("a-input-approved");' +
@@ -13,10 +13,10 @@ var nameChecker = function() {
     '.html("Velg navn").removeAttr("onclick");' +
     '$(".a-js-tryAnother").show();';
     $('.a-js-validator').find('.a-validatorInfo').eq(1).find('i')
-    .addClass('a-validatorInfo-icon-approved');
+      .addClass('a-validatorInfo-icon-approved');
     $('.a-js-validator').find('.a-validatorInfo').css('display', 'inline-block')
-    .eq(1)
-    .hide();
+      .eq(1)
+      .hide();
     if ($('.a-js-tryAnother').length === 0) {
       $('<button/>', {
         type: 'button',
@@ -26,47 +26,47 @@ var nameChecker = function() {
     }
     $('.a-js-tryAnother').hide().on('click', function() {
       $('.a-js-validator').find('input[type=text]').removeAttr('disabled')
-      .parent()
-      .removeClass('disabled')
-      .removeClass('a-input-approved');
+        .parent()
+        .removeClass('disabled')
+        .removeClass('a-input-approved');
       $('.a-js-tryAnother').hide();
       $('.a-js-validator').find('.a-validatorInfo').eq(0).show();
       $('.a-js-validator').find('.a-validatorInfo').eq(1).hide();
       $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-      .html(btnText)
-      .attr('onclick', '$(".a-js-validator").find(".a-message-error").show()')
-      .hide();
+        .html(btnText)
+        .attr('onclick', '$(".a-js-validator").find(".a-message-error").show()')
+        .hide();
       $('.a-js-validator').find('input[type=text]').val('');
       $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(1)
-      .show();
+        .show();
     });
     $('.a-js-validator').find('.a-message-error');
     toggleBtns = function(el) {
       if ($(el).length > 0 && $(el).val().length > 0) {
         $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-        .show();
+          .show();
         $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(1)
-        .hide();
+          .hide();
         if (
           $('.a-js-validator').find('input[type=text]').val()
-          .indexOf($('.a-personSwitcher-name').attr('title').toLowerCase()
-          .split(' ')[1]) !== -1 ||
+            .indexOf($('.a-personSwitcher-name').attr('title').toLowerCase()
+              .split(' ')[1]) !== -1 ||
           $('.a-js-validator').find('input[type=text]').val()
-          .indexOf($('.a-personSwitcher-name').attr('title')
-          .split(' ')[1]) !== -1
+            .indexOf($('.a-personSwitcher-name').attr('title')
+              .split(' ')[1]) !== -1
         ) {
           $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-          .attr('onclick', initAction);
+            .attr('onclick', initAction);
         } else {
           $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-          .attr('onclick',
-          '$(".a-js-validator").find(".a-message-error").show()');
+            .attr('onclick',
+              '$(".a-js-validator").find(".a-message-error").show()');
         }
       } else {
         $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-        .hide();
+          .hide();
         $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(1)
-        .show();
+          .show();
       }
     };
     toggleBtns($('.a-js-validator').find('input[type=text]'));
@@ -81,9 +81,9 @@ var nameChecker = function() {
       if (e.which === 13) {
         e.preventDefault(); e.stopPropagation();
         if ($('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-        .is(':visible')) {
+          .is(':visible')) {
           $('.a-js-validator').find('.a-btn-group').find('.a-btn').eq(0)
-          .click();
+            .click();
         }
       }
     });

--- a/source/js/prototyping/modules/onboardingUtilities.js
+++ b/source/js/prototyping/modules/onboardingUtilities.js
@@ -152,16 +152,16 @@ var onboardingSeek = function(_count, _steps) {
     $('.onboarding-wrapper').css('top', (-1 - mod) + 'px').css('left', '2px');
     setTimeout(function() {
       $('.onboarding-wrapper')
-      .css('top', ((verticalJiggle * -0.5) - mod) + 'px')
-      .css('left', (horizontalJiggle * -0.5) + 'px');
+        .css('top', ((verticalJiggle * -0.5) - mod) + 'px')
+        .css('left', (horizontalJiggle * -0.5) + 'px');
       setTimeout(function() {
         $('.onboarding-wrapper')
-        .css('top', ((verticalJiggle * 0.25) - mod) + 'px')
-        .css('left', (horizontalJiggle * 0.25) + 'px');
+          .css('top', ((verticalJiggle * 0.25) - mod) + 'px')
+          .css('left', (horizontalJiggle * 0.25) + 'px');
         setTimeout(function() {
           $('.onboarding-wrapper')
-          .css('top', ((verticalJiggle * -0.125) - mod) + 'px')
-          .css('left', (horizontalJiggle * -0.125) + 'px');
+            .css('top', ((verticalJiggle * -0.125) - mod) + 'px')
+            .css('left', (horizontalJiggle * -0.125) + 'px');
           setTimeout(function() {
             $('.onboarding-wrapper').css('top', (-1 - mod) + 'px').css('left', '2px');
           }, 100);


### PR DESCRIPTION
As a result when bumping from eslint version 3.18.1 to 4.18.2 some new lint-errors was introduced. All of them was of type "Expected indentation"-errors.