### PR TITLE
Add dark-blue border to checkbox and radiobuttons when focus

### DIFF
--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -563,6 +563,7 @@ textarea {
 
     &:focus~.custom-control-label {
       &::before {
+        border: 2px solid $blue-darker;
         box-shadow: none;
       }
     }
@@ -660,6 +661,7 @@ textarea {
 
     &:focus~.custom-control-label {
       &::before {
+        border: 2px solid $blue-darker;
         box-shadow: none;
       }
     }


### PR DESCRIPTION
Fix for focus-bug: When using keyboard (tab) to navigate in infoportal, portal and altinndigital, the checkboxes and radiobuttons had no visible focus-style. 