### PR TITLE
Remove source and patterns from dist-folder and npm package. major version bump

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,8 +4,7 @@ public
 yarn.lock
 .sass-cache/*
 sass-cache/
-source/css/scss/episerver/epi.min.scss
-source/css/style.css.map
+source/
 *.log
 npm-debug.log*
 .DS_Store
@@ -19,7 +18,6 @@ npm-debug.log*
 
 linters/
 export/
-source/fonts/*
 **/fonts/DIN*
 
 TestResults/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -427,7 +427,7 @@ gulp.task('patternlab:serve-altinnett', serve('altinnett'));
 gulp.task('patternlab:serve-infoportal', serve('infoportal'));
 gulp.task('patternlab:serve-portal', serve('portal'));
 
-gulp.task('dist',
+gulp.task('dist-include-patterns',
   gulp.series(
     'pl-clean:dist',
     'patternlab:prebuild',
@@ -439,6 +439,18 @@ gulp.task('dist',
     'pl-copy:distribution-js'
   )
 );
+
+
+gulp.task('dist',
+  gulp.series(
+    'pl-clean:dist',
+    'pl-copy:distribution-fonts',
+    'pl-copy:distribution-css',
+    'pl-copy:distribution-images',
+    'pl-copy:distribution-js'
+  )
+);
+
 gulp.task('default', gulp.series('patternlab:serve-all'));
 
 /** ***************************************************

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-designsystem",
-  "version": "2.6.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altinn-designsystem",
-  "version": "2.6.3",
+  "version": "3.0.0",
   "description": "Altinn Design system based on Pattern Lab.",
   "keywords": [
     "Altinn",
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "precommit-msg": "echo 'Pre-commit: Linting js and scss' && exit 0",
-    "dist": "gulp dist --max_old_space_size=4096",
+    "dist": "gulp dist",
+    "dist-include-patterns": "gulp dist-include-patterns --max_old_space_size=8192",
     "lint": "eslint source/js/",
     "patterns": "gulp patternlab:patternsonly",
     "purify": "purifycss public/css/style.css public/**/*.html public/**/*.js --info --rejected --out public/css/index.css",


### PR DESCRIPTION
This removes the `source`-folder from being included in the generated npm package, reducing package size by 90%.

This also removes inclusion of the `patterns`-folder in the `dist`-folder. Added a new npm/gulp-job called `dist-include-patterns` that can be used for old behavior.

This reduces time required for npm run dist from ~5 minutes to ~5 seconds.