### PR TITLE
minor margin-correction on dropdown list when dropdown is flipped up

### DIFF
--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -963,10 +963,10 @@ textarea {
   width: 100%;
   max-height: 300px;
   padding: 0 $spacer * 2 0 $spacer * 2;
-  margin-top: 0;
+  margin-top: -2px;
+  margin-bottom: -2px;
   overflow-y: auto;
   border: 2px solid $blue-dark;
-  border-top: none;
   border-radius: 0;
 }
 

--- a/source/css/scss-common/base/_forms.scss
+++ b/source/css/scss-common/base/_forms.scss
@@ -970,6 +970,11 @@ textarea {
   border-radius: 0;
 }
 
+.a-dropdown-menu-direction-down {
+  // sass-lint:disable-block no-important
+  transform: translate3d(0, 36px, 0) !important;
+}
+
 .a-dropdown-item {
   position: relative;
   min-height: $spacer * 3;


### PR DESCRIPTION
This is to correct the current errors on the dropdown lists in altinn from:
![image](https://user-images.githubusercontent.com/5472011/76412743-722bbc80-6394-11ea-90b0-4374919b51b8.png)

to this:
![image](https://user-images.githubusercontent.com/5472011/76412775-840d5f80-6394-11ea-95cd-b18d9ccbf2fa.png)
