### PR TITLE
Updated the CSS class .a-iconStrikeThrough with overflow-wrap:normal

### DIFF
--- a/source/css/scss-common/base/_global-classes.scss
+++ b/source/css/scss-common/base/_global-classes.scss
@@ -462,6 +462,7 @@ hr {
 
 .a-iconStrikeThrough {
   padding-left: 3px;
+  overflow-wrap: normal;
 
   &::after {
     position: relative;


### PR DESCRIPTION
… av strek over operasjonsikon som ikke er "deselected" (Bug 47675)