### PR TITLE
Update to remove node-sass depenceny

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,5 @@
     "precommit-msg",
     "sass",
     "lint"
-  ],
-  "dependencies": {
-    "node-sass": "^5.0.0"
-  }
+  ]
 }


### PR DESCRIPTION
PR 409 which bumps design system version from 3.0.0 to 3.0.1 added a dependency to node-sass by mistake.
node-sass again has dependency to node-gyp which has dependency to python, and causes all kinds of build errors when running npm install, unless the user has all the required build tools setup.