### PR TITLE
Block Search indexing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width" />
+    <meta name="robots" content="noindex">
     <title>Altinn designsystem</title>
     <link rel="stylesheet" href="./gh-pages/altinn/css/style.dist.landingsside.css" media="all">
 </head>


### PR DESCRIPTION
For å unngå forvirring når man søker etter Altinn designsystem, ønsker vi å fjerne det gamle designsystemet (patternlab) fra indekseringen. 